### PR TITLE
[SHACK-354] Use registry keys on windows for install path

### DIFF
--- a/main.js
+++ b/main.js
@@ -6,7 +6,6 @@ const aboutDialog = require('./src/about.js');
 const helpers = require('./src/helpers.js');
 const { mixlibInstallUpdater } = require('./src/mixlib_install_updater.js');
 const workstation = require('./src/chef_workstation.js');
-const util = require('util'); // debug inspection
 
 // appLock will be true if this is the first instance.
 let appLock = !app.makeSingleInstance(function (argv, cwd) {});
@@ -113,7 +112,7 @@ mixlibInstallUpdater.on('update-available', (updateInfo) => {
     // don't set the tray notification state, because they're viewing that
     // notification now.
     const updateAvailableDialog = require('./src/update_available_dialog.js');
-    updateAvailableDialog.open(updateInfo, workstation.getVersionDirect());
+    updateAvailableDialog.open(updateInfo, workstation.getVersion());
   } else {
     WSTray.instance().displayNotification(true);
   }
@@ -135,7 +134,7 @@ mixlibInstallUpdater.on('end-update-check', () => {
 
 
 app.on('do-update-check', () => {
-  mixlibInstallUpdater.checkForUpdates(workstation.getVersionDirect());
+  mixlibInstallUpdater.checkForUpdates(workstation.getVersion());
 });
 
 app.on('ready', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -127,6 +127,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -545,7 +546,8 @@
     "bluebird": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.2.tgz",
-      "integrity": "sha512-dhHTWMI7kMx5whMQntl7Vr9C6BvV10lFXDAasnqnrMYhXVCzzk6IO9Fo2L75jXHT07WrOngL1WDXOp+yYS91Yg=="
+      "integrity": "sha512-dhHTWMI7kMx5whMQntl7Vr9C6BvV10lFXDAasnqnrMYhXVCzzk6IO9Fo2L75jXHT07WrOngL1WDXOp+yYS91Yg==",
+      "dev": true
     },
     "bluebird-lst": {
       "version": "1.0.5",
@@ -850,6 +852,7 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
       "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -1014,6 +1017,7 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -1021,7 +1025,8 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
     },
     "combined-stream": {
       "version": "1.0.7",
@@ -1767,7 +1772,8 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
     },
     "escodegen": {
       "version": "1.11.0",
@@ -2841,7 +2847,8 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
     },
     "has-value": {
       "version": "1.0.0",
@@ -3845,15 +3852,6 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
-    },
-    "node-powershell": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/node-powershell/-/node-powershell-3.3.1.tgz",
-      "integrity": "sha1-u/drKfCR7YPq4WrZ56GAoT820RM=",
-      "requires": {
-        "bluebird": "^3.5.1",
-        "chalk": "^2.1.0"
-      }
     },
     "normalize-package-data": {
       "version": "2.4.0",
@@ -8234,6 +8232,7 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
     "electron-debug": "^2.0.0",
     "electron-is": "^3.0.0",
     "electron-osx-appearance": "^0.1.1",
-    "request": "^2.0.0",
-    "node-powershell": "^3.3.1"
+    "request": "^2.0.0"
   }
 }

--- a/src/about.html
+++ b/src/about.html
@@ -16,7 +16,12 @@
         <div class="col col-9">
           <h1 class="extra-large"><script>document.write(getDisplayName())</script></h1>
           <div class="strong-list">
-            <p><strong>Version</strong> <script>document.write(getAppVersion())</script></p>
+            <p><strong>Version</strong>
+              <script>
+                const workstation = require('./chef_workstation.js');
+                document.write(workstation.getVersion());
+              </script>
+            </p>
             <div class="p-inline-button">
               <p><strong>Release</strong> <script>document.write(getReleaseChannel())</script></p>
               <button disabled class="secondary">Switch to current release</button>

--- a/src/chef_workstation.js
+++ b/src/chef_workstation.js
@@ -8,6 +8,7 @@ const CWS_REG_NODE = 'HKLM\\SOFTWARE\\Chef\\Chef Workstation';
 const CWS_REG_KEY_BIN_DIR = "BinDir";
 const CWS_REG_KEY_INSTALL_DIR = "InstallDir";
 const is = require('electron-is');
+const isDev = require('electron-is-dev');
 const { execFileSync } = require('child_process');
 
 const registryCache = {};
@@ -31,23 +32,27 @@ function syncGetRegistryValue(baseKey, key, type = "REG_SZ") {
 
 function getVersion() {
   let manifestPath = null;
-  if (is.windows()) {
+  if (isDev) {
+    return "development";
+  } else if (is.windows()) {
     manifestPath = syncGetRegistryValue(CWS_REG_NODE, CWS_REG_KEY_INSTALL_DIR) + "version-manifest.json";
   } else {
-    manifestPath = "/opt/chef-workstation/version-manifest.json"
+    manifestPath = "/opt/chef-workstation/version-manifest.json";
   }
   const manifest = require(manifestPath);
-  return manifest.build_version
+  return manifest.build_version;
 }
 
 function getPathToChefBinary(binBaseName) {
   let result = null;
-  if (is.windows()) {
+  if (isDev) {
+    return result;
+  } else if (is.windows()) {
     result = syncGetRegistryValue(CWS_REG_NODE, CWS_REG_KEY_BIN_DIR) + binBaseName + ".bat"
   } else {
     result = "/opt/chef-workstation/bin/" + binBaseName;
   }
-  return result
+  return result;
 }
 
 function getPlatformInfo() {
@@ -61,6 +66,9 @@ function queryOhai(attributes) {
   var path;
 
   var path = getPathToChefBinary("ohai");
+  if (path == null) {
+    return null;
+  }
   var ohai = execFileSync(path, attributes);
 
   // convert output from:

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,6 +1,5 @@
 const package = require('../package.json');
 var isDev = require('electron-is-dev');
-// var path = require('path');
 
 function getProductName() {
   return package.productName;

--- a/src/mixlib_install_updater.js
+++ b/src/mixlib_install_updater.js
@@ -13,6 +13,11 @@ function checkForUpdates(currentVersion) {
   if (_platformInfo == null) {
     const workstation = require('./chef_workstation.js');
     _platformInfo = workstation.getPlatformInfo();
+    if (_platformInfo == null) {
+      this.emit('update-not-available');
+      this.emit('end-update-check');
+      return;
+    }
   }
 
 
@@ -36,9 +41,9 @@ function checkForUpdates(currentVersion) {
     }
 
     if (currentVersion != body.version) {
-      this.emit('update-available', body)
+      this.emit('update-available', body);
     } else {
-      this.emit('update-not-available')
+      this.emit('update-not-available');
     }
     this.emit('end-update-check');
   });

--- a/src/ws_tray.js
+++ b/src/ws_tray.js
@@ -39,12 +39,8 @@ function WSTray() {
       app.dock.hide()
     }
     isNotifying = false;
-    // https://github.com/hovancik/stretchly/blob/master/app/main.js#L647
     setToolTip();
-
-    // Now that the tray is initialized, kick off the call that will eventually update
-    // the version to display the correct version.
-    chefWorkstation.getVersion(setVersion);
+    setVersion(chefWorkstation.getVersion());
 }
 
 function setNotifyIcon() {


### PR DESCRIPTION
    Switch getVersion to use registry lookup for install path key
    recently added to WS, and have both platforms load version
    data from version-manifest.json