### PR TITLE
[SHACK-377] Disable Updates and Update From Current

### DIFF
--- a/assets/css/about.css
+++ b/assets/css/about.css
@@ -48,3 +48,7 @@ a p:parent {
 section.link-list p:not(:last-child) {
   margin-bottom: 20px;
 }
+
+#update-channel {
+  text-transform: capitalize;
+}

--- a/main.js
+++ b/main.js
@@ -46,7 +46,7 @@ function createMenu() {
     {
       id: 'updateCheck',
       label: pendingVersionUpdate ? ('Download Workstation v' + pendingVersionUpdate)  : 'Check for updates...',
-      click: () => { requestFromMenu = true;  app.emit('do-update-check') }
+      click: () => { app.emit('do-update-check', true) }
     },
     {type: 'separator'},
     {
@@ -81,7 +81,11 @@ function startApp() {
   backgroundWindow.loadURL(modalPath)
   createTray();
   // Defer intiial update check until app is fully rendered
-  app.emit('do-update-check');
+  if (workstation.isUpdatesEnabled()) {
+    app.emit('do-update-check');
+  } else {
+    trayMenu.getMenuItemById('updateCheck').enabled  = false;
+  }
 }
 
 function quitApp() {
@@ -133,7 +137,8 @@ mixlibInstallUpdater.on('end-update-check', () => {
 });
 
 
-app.on('do-update-check', () => {
+app.on('do-update-check', (fromUser=false) => {
+  requestFromMenu = fromUser;
   mixlibInstallUpdater.checkForUpdates(workstation.getVersion());
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,11 @@
       "integrity": "sha512-XtGk+IF57pr852UK1AhQJXqmm1WmSgS5uISL+LPs0z/iAxXouMvdlLJrHPeukP6gd7yR2rDTMSMkHNODgwIq7A==",
       "dev": true
     },
+    "@iarna/toml": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.0.tgz",
+      "integrity": "sha512-ESqb7nwPdXRZ3AXVub1ToyeIf9bkXY4Cs21DSmr+ns705Dcz6KjB7gVXRxH93kwP8Vbx5Lg1dYewAIHmOTSg+A=="
+    },
     "@types/node": {
       "version": "8.10.34",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.34.tgz",
@@ -221,7 +226,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
@@ -267,7 +272,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
@@ -519,7 +524,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
@@ -1038,7 +1043,7 @@
     },
     "commander": {
       "version": "2.15.1",
-      "resolved": "http://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
       "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
       "dev": true
     },
@@ -1074,7 +1079,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
@@ -1124,7 +1129,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
@@ -1206,7 +1211,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
@@ -2168,8 +2173,7 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2190,14 +2194,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2212,20 +2214,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2342,8 +2341,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2355,7 +2353,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2370,7 +2367,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2378,14 +2374,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2404,7 +2398,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2485,8 +2478,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2498,7 +2490,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2584,8 +2575,7 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2621,7 +2611,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2641,7 +2630,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2685,14 +2673,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -2800,7 +2786,7 @@
     },
     "got": {
       "version": "6.7.1",
-      "resolved": "http://registry.npmjs.org/got/-/got-6.7.1.tgz",
+      "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
       "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
       "dev": true,
       "requires": {
@@ -3086,7 +3072,7 @@
     },
     "is-builtin-module": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
@@ -3218,7 +3204,7 @@
     },
     "is-obj": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
@@ -3463,7 +3449,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
@@ -3508,7 +3494,7 @@
     },
     "load-json-file": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
@@ -3720,7 +3706,7 @@
     },
     "minimist": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
       "dev": true
     },
@@ -3747,7 +3733,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -3756,7 +3742,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         }
@@ -7533,7 +7519,7 @@
     },
     "readable-stream": {
       "version": "1.1.14",
-      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
       "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
       "dev": true,
       "requires": {
@@ -7562,7 +7548,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
@@ -8271,7 +8257,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
@@ -8330,7 +8316,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
@@ -8873,7 +8859,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {
@@ -9091,7 +9077,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "xvfb-maybe": "^0.2.1"
   },
   "dependencies": {
+    "@iarna/toml": "^2.2.0",
     "electron-debug": "^2.0.0",
     "electron-is": "^3.0.0",
     "electron-osx-appearance": "^0.1.1",

--- a/src/about.html
+++ b/src/about.html
@@ -18,13 +18,12 @@
           <div class="strong-list">
             <p><strong>Version</strong>
               <script>
-                const workstation = require('./chef_workstation.js');
-                document.write(workstation.getVersion());
+                document.write(getWorkstationVersion());
               </script>
             </p>
             <div class="p-inline-button">
-              <p><strong>Release</strong> <script>document.write(getReleaseChannel())</script></p>
-              <button disabled class="secondary">Switch to current release</button>
+              <p id='update-channel'><strong>Release</strong> <script>document.write(getUpdatesChannel())</script></p>
+              <button id='update-channel-btn' class="secondary" onclick="toggleUpdatesChannel()" disabled>Switch to <script>document.write(getUpdatesChannel())</script> release</button>
               <button class="info"></button>
             </div>
           </div>
@@ -43,5 +42,8 @@
         <p class="small">&#9400; 2008-2018 Chef Software, Inc. All Rights Reserved.</p>
       </section>
     </main>
+    <script>
+      document.getElementById("update-channel-btn").disabled=isUpdatesDisabled();
+    </script>
   </body>
 </html>

--- a/src/about.js
+++ b/src/about.js
@@ -1,5 +1,6 @@
 const { shell, BrowserWindow } = require('electron');
 const path = require('path');
+const workstation = require('./chef_workstation.js');
 const helpers = require('./helpers.js');
 
 const width = process.platform === 'darwin' ? 510 : 530;
@@ -48,6 +49,27 @@ function openReleaseNotes() {
 function openPackageDetails() {
   detailsPath = path.join('file://', helpers.getResourcesPath(), 'assets/html/package_details.html');
   shell.openExternal(detailsPath)
+}
+
+function getWorkstationVersion() {
+  return workstation.getVersion();
+}
+
+function getUpdatesChannel() {
+  return workstation.getUpdatesChannel();
+}
+
+function toggleUpdatesChannel() {
+  const { app } = require('electron').remote;
+  let currentChannel = workstation.getUpdatesChannel();
+  workstation.toggleUpdatesChannel();
+  document.getElementById('update-channel-btn').textContent = 'Switch to ' + currentChannel + ' channel';
+  document.getElementById('update-channel').innerHTML = '<strong>Release</strong>' + getUpdatesChannel();
+  app.emit('do-update-check', true);
+}
+
+function isUpdatesDisabled() {
+  return !workstation.isUpdatesEnabled();
 }
 
 module.exports.open = open;

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -9,14 +9,6 @@ function getDisplayName() {
   return package.displayName;
 }
 
-function getAppVersion() {
-  return package.version;
-}
-
-function getReleaseChannel() {
-  return 'Stable';
-}
-
 function getResourcesPath() {
   if (isDev) {
     return path.join(__dirname, '../');
@@ -27,6 +19,4 @@ function getResourcesPath() {
 
 module.exports.getProductName = getProductName;
 module.exports.getDisplayName = getDisplayName;
-module.exports.getAppVersion = getAppVersion;
-module.exports.getReleaseChannel = getReleaseChannel;
 module.exports.getResourcesPath = getResourcesPath;

--- a/src/mixlib_install_updater.js
+++ b/src/mixlib_install_updater.js
@@ -11,8 +11,16 @@ function MixlibInstallUpdater() {
 
 function checkForUpdates(currentVersion) {
   this.emit('start-update-check');
+  const workstation = require('./chef_workstation.js');
+  _channel = workstation.getUpdatesChannel();
+  _enabled = workstation.isUpdatesEnabled();
+  if (_enabled == false) {
+    this.emit('update-not-available');
+    this.emit('end-update-check');
+    return;
+  }
+
   if (_platformInfo == null) {
-    const workstation = require('./chef_workstation.js');
     _platformInfo = workstation.getPlatformInfo();
     
     if (_platformInfo == null) {
@@ -22,7 +30,7 @@ function checkForUpdates(currentVersion) {
     }
   }
 
-  let url = util.format(OMNITRUCK_URL, "stable", _platformInfo.platform, _platformInfo.platform_version
+  let url = util.format(OMNITRUCK_URL, _channel, _platformInfo.platform, _platformInfo.platform_version
     , "latest", _platformInfo.kernel_machine);
   request(url, { json: true }, (err, res, body) => {
     if (err)  {

--- a/src/no_update.html
+++ b/src/no_update.html
@@ -15,8 +15,8 @@
           <script>document.write(getDisplayName())</script> is up-to-date!
         </div>
         <div>
-          <script>document.write(getAppVersion())</script> is the latest
-          <script>document.write(getReleaseChannel())</script> release available.
+          <script>document.write(getWorkstationVersion())</script> is the latest
+          <script>document.write(getUpdatesChannel())</script> release available.
         </div>
       </div>
     </div>

--- a/src/no_update.js
+++ b/src/no_update.js
@@ -1,5 +1,14 @@
 const { remote }  = require('electron');
 const noUpdateWindow = remote.getCurrentWindow();
+const workstation = require('./chef_workstation.js');
+
+function getWorkstationVersion() {
+  return workstation.getVersion();
+}
+
+function getUpdatesChannel() {
+  return workstation.getUpdatesChannel();
+}
 
 function closeDialog() {
   noUpdateWindow.close();

--- a/src/update_available.html
+++ b/src/update_available.html
@@ -26,9 +26,9 @@
             document.write(updateInfo.version)
           </script>
           is the latest
-          <script>document.write(getReleaseChannel())</script>
+          <script>document.write(getUpdatesChannel())</script>
           release, you have
-          <script>document.write(currentWindow.workstationVersion)</script>.
+          <script>document.write(getWorkstationVersion())</script>.
         </div>
       </div>
     </div>

--- a/src/update_available.js
+++ b/src/update_available.js
@@ -1,8 +1,15 @@
 const { remote, shell }  = require('electron');
-const is = require('electron-is');
 const updateAvailableWindow = remote.getCurrentWindow();
 const updateInfo = updateAvailableWindow.updateInfo;
-const workstationVersion = updateAvailableWindow.workstationVersion;
+const workstation = require('./chef_workstation.js');
+
+function getWorkstationVersion() {
+  return workstation.getVersion();
+}
+
+function getUpdatesChannel() {
+  return workstation.getUpdatesChannel();
+}
 
 function closeDialog() {
   window.close();


### PR DESCRIPTION
This change implements simple config reading/writting from
~/.chef-workstation/config.toml. This is used to toggle update
channel and also disable updates.

Signed-off-by: Jon Morrow <jmorrow@chef.io>