### PR TITLE
[Shack-377] Update interval and cleanup

### DIFF
--- a/main.js
+++ b/main.js
@@ -31,13 +31,15 @@ require('electron-debug')({enabled: is_debug});
 
 let tray = null;
 let trayMenu = null;
-let requestFromMenu = false;
+let requestFromUser = false;
 
 // Background window is hidden and will be used to run service processes. It is
 // here now so it is the first/main window of the app meaning the about pop up
 // won't close the app when closed.
 let backgroundWindow = null;
 let pendingVersionUpdate = null;
+
+let updateCheckInterval = null;
 
 function createMenu() {
   // The clicks here take a function so that additional parameters such as
@@ -46,7 +48,7 @@ function createMenu() {
     {
       id: 'updateCheck',
       label: pendingVersionUpdate ? ('Download Workstation v' + pendingVersionUpdate)  : 'Check for updates...',
-      click: () => { requestFromMenu = true;  app.emit('do-update-check') }
+      click: () => { triggerUpdateCheck(true) }
     },
     {type: 'separator'},
     {
@@ -75,16 +77,23 @@ function createTray() {
   tray.setContextMenu(trayMenu);
 }
 
+function triggerUpdateCheck(requestFromUser=false) {
+  app.emit('do-update-check', requestFromUser);
+}
+
 function startApp() {
   const modalPath = `file://${__dirname}/process.html`
   backgroundWindow = new BrowserWindow({ show: false });
   backgroundWindow.loadURL(modalPath)
   createTray();
-  // Defer intiial update check until app is fully rendered
-  app.emit('do-update-check');
+  // Do first check and setup update checks.
+  triggerUpdateCheck();
+  let minutes = 60*8; // Every 8 hours.
+  updateCheckInterval = setInterval(triggerUpdateCheck, minutes*60*1000);
 }
 
 function quitApp() {
+  clearInterval(updateCheckInterval);
   backgroundWindow = null;
   app.quit();
 }
@@ -96,30 +105,28 @@ mixlibInstallUpdater.on('start-update-check', () => {
 
 mixlibInstallUpdater.on('update-not-available', () => {
   // If they picked the menu option, show a notification dialog.
-  if (requestFromMenu) {
+  if (requestFromUser) {
     const noUpdateDialog = require('./src/no_update_dialog.js');
     noUpdateDialog.open();
   }
-  WSTray.instance().displayNotification(false);
+  WSTray.instance().setUpdateAvailable(false);
 });
 
 mixlibInstallUpdater.on('update-available', (updateInfo) => {
   // Only display the notification. Changing the menu text is a lot of work
   // and will be done in the next re-factor.
   WSTray.instance().setUpdateAvailable(true);
-  if (requestFromMenu)  {
+  if (requestFromUser)  {
     // If they picked the menu option, show a notification dialog.
     // don't set the tray notification state, because they're viewing that
     // notification now.
     const updateAvailableDialog = require('./src/update_available_dialog.js');
     updateAvailableDialog.open(updateInfo, workstation.getVersion());
-  } else {
-    WSTray.instance().displayNotification(true);
   }
 });
 
 mixlibInstallUpdater.on('error', (error) => {
-  if (requestFromMenu) {
+  if (requestFromUser) {
     // TODO probably don't show the error except to say try again later, UNLESS
     // we can identify a user-correctable problem (proxy,. etc)
     dialog.showErrorBox('Error', error == null ? "unknown" : error.toString());
@@ -128,12 +135,12 @@ mixlibInstallUpdater.on('error', (error) => {
 
 // reset state of update-related activities when update check is complete
 mixlibInstallUpdater.on('end-update-check', () => {
-  requestFromMenu = false;
+  requestFromUser = false;
   trayMenu.getMenuItemById('updateCheck').enabled  = true;
 });
 
-
-app.on('do-update-check', () => {
+app.on('do-update-check', (_requestFromUser) => {
+  requestFromUser = _requestFromUser;
   mixlibInstallUpdater.checkForUpdates(workstation.getVersion());
 });
 

--- a/src/about.html
+++ b/src/about.html
@@ -9,6 +9,7 @@
     <link rel="stylesheet" href="../assets/css/about.css">
     <script src="about.js"></script>
     <script src="helpers.js"></script>
+    <script>const workstation = require('./chef_workstation.js');</script>
   </head>
   <body>
     <main>
@@ -18,7 +19,6 @@
           <div class="strong-list">
             <p><strong>Version</strong>
               <script>
-                const workstation = require('./chef_workstation.js');
                 document.write(workstation.getVersion());
               </script>
             </p>

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -9,10 +9,6 @@ function getDisplayName() {
   return package.displayName;
 }
 
-function getAppVersion() {
-  return package.version;
-}
-
 function getReleaseChannel() {
   return 'Stable';
 }
@@ -27,6 +23,5 @@ function getResourcesPath() {
 
 module.exports.getProductName = getProductName;
 module.exports.getDisplayName = getDisplayName;
-module.exports.getAppVersion = getAppVersion;
 module.exports.getReleaseChannel = getReleaseChannel;
 module.exports.getResourcesPath = getResourcesPath;

--- a/src/no_update.html
+++ b/src/no_update.html
@@ -6,6 +6,7 @@
     <link rel="stylesheet" href="../assets/css/no_update.css">
     <script src="helpers.js"></script>
     <script src="no_update.js"></script>
+    <script>const workstation = require('./chef_workstation.js');</script>
   </head>
   <body>
     <div class="top-panel">
@@ -15,7 +16,7 @@
           <script>document.write(getDisplayName())</script> is up-to-date!
         </div>
         <div>
-          <script>document.write(getAppVersion())</script> is the latest
+          <script>document.write(workstation.getVersion())</script> is the latest
           <script>document.write(getReleaseChannel())</script> release available.
         </div>
       </div>

--- a/src/update_available.html
+++ b/src/update_available.html
@@ -6,10 +6,8 @@
     <link rel="stylesheet" href="../assets/css/update_available.css">
     <script src="helpers.js"></script>
     <script src="update_available.js"></script>
+    <script>const workstation = require('./chef_workstation.js');</script>
     <script>
-      // TODO - why can we access updateInfo without any problems,
-      //        but in order to get 'workstationVersion' we need to go through
-      //        currentWindow?
       var electron = require('electron');
       var currentWindow = electron.remote.getCurrentWindow();
     </script>
@@ -28,7 +26,7 @@
           is the latest
           <script>document.write(getReleaseChannel())</script>
           release, you have
-          <script>document.write(currentWindow.workstationVersion)</script>.
+          <script>document.write(workstation.getVersion())</script>.
         </div>
       </div>
     </div>

--- a/src/update_available.js
+++ b/src/update_available.js
@@ -1,8 +1,6 @@
 const { remote, shell }  = require('electron');
-const is = require('electron-is');
 const updateAvailableWindow = remote.getCurrentWindow();
 const updateInfo = updateAvailableWindow.updateInfo;
-const workstationVersion = updateAvailableWindow.workstationVersion;
 
 function closeDialog() {
   window.close();

--- a/src/ws_tray.js
+++ b/src/ws_tray.js
@@ -71,6 +71,7 @@ function setContextMenu(contextMenu) {
 
 function setUpdateAvailable(u) {
     updateAvailable = u;
+    displayNotification(updateAvailable);
     setToolTip();
 }
 


### PR DESCRIPTION
This change adds an update interval so we check for
updates every 8 hours. It also cleans up our dialogs
and windows to consistently get the app version from
chef-workstation. Finally, the 'do-update-check' event
now takes a boolean to indicate if the check was triggered
by the user.

Signed-off-by: Jon Morrow <jmorrow@chef.io>