### PR TITLE
[SHACK-377] Configurable update channel

### DIFF
--- a/assets/css/about.css
+++ b/assets/css/about.css
@@ -48,3 +48,7 @@ a p:parent {
 section.link-list p:not(:last-child) {
   margin-bottom: 20px;
 }
+
+#update-channel {
+  text-transform: capitalize;
+}

--- a/src/about.html
+++ b/src/about.html
@@ -23,7 +23,7 @@
               </script>
             </p>
             <div class="p-inline-button">
-              <p><strong>Release</strong> <script>document.write(getReleaseChannel())</script></p>
+              <p id='update-channel'><strong>Release</strong> <script>document.write(workstation.getUpdateChannel())</script></p>
               <button disabled class="secondary">Switch to current release</button>
               <button class="info"></button>
             </div>

--- a/src/chef_workstation.js
+++ b/src/chef_workstation.js
@@ -135,9 +135,19 @@ function getUpdateIntervalMinutes() {
   }
 }
 
+function getUpdateChannel() {
+  let userConfig = getUserConfig();
+  if (userConfig.updates == undefined || userConfig.updates.channel == undefined) {
+    return 'stable';
+  } else {
+    return userConfig.updates.channel;
+  }
+}
+
 module.exports.getVersion = getVersion;
 module.exports.getPlatformInfo = getPlatformInfo;
 
 // Config functions
 module.exports.areUpdatesEnabled = areUpdatesEnabled;
 module.exports.getUpdateIntervalMinutes = getUpdateIntervalMinutes;
+module.exports.getUpdateChannel = getUpdateChannel;

--- a/src/mixlib_install_updater.js
+++ b/src/mixlib_install_updater.js
@@ -2,6 +2,7 @@ const events = require('events');
 const isVersionGreaterThan = require('semver').gt;
 const request = require('request');
 const util = require('util'); // formatting
+const workstation = require('./chef_workstation.js');
 const OMNITRUCK_URL = "https://omnitruck.chef.io/%s/chef-workstation/metadata/?p=%s&pv=%s&v=%s&m=%s&prerelease=false&nightlies=false";
 let _platformInfo = null;
 
@@ -11,8 +12,8 @@ function MixlibInstallUpdater() {
 
 function checkForUpdates(currentVersion) {
   this.emit('start-update-check');
+  let _channel = workstation.getUpdateChannel();
   if (_platformInfo == null) {
-    const workstation = require('./chef_workstation.js');
     _platformInfo = workstation.getPlatformInfo();
     
     if (_platformInfo == null) {
@@ -22,7 +23,7 @@ function checkForUpdates(currentVersion) {
     }
   }
 
-  let url = util.format(OMNITRUCK_URL, "stable", _platformInfo.platform, _platformInfo.platform_version
+  let url = util.format(OMNITRUCK_URL, _channel, _platformInfo.platform, _platformInfo.platform_version
     , "latest", _platformInfo.kernel_machine);
   request(url, { json: true }, (err, res, body) => {
     if (err)  {

--- a/src/no_update.html
+++ b/src/no_update.html
@@ -17,7 +17,7 @@
         </div>
         <div>
           <script>document.write(workstation.getVersion())</script> is the latest
-          <script>document.write(getReleaseChannel())</script> release available.
+          <script>document.write(workstation.getUpdateChannel())</script> release available.
         </div>
       </div>
     </div>

--- a/src/update_available.html
+++ b/src/update_available.html
@@ -24,7 +24,7 @@
             document.write(updateInfo.version)
           </script>
           is the latest
-          <script>document.write(getReleaseChannel())</script>
+          <script>document.write(workstation.getUpdateChannel())</script>
           release, you have
           <script>document.write(workstation.getVersion())</script>.
         </div>


### PR DESCRIPTION
This change adds a config item to ~/.chef-workstation/config.toml:

```
[updates]
channel = 'stable'
```

When set updates check the set channel. Valid values are 'stable' and 'current'.

Signed-off-by: Jon Morrow <jmorrow@chef.io>