### PR TITLE
 [SHACK-377] Set update channel button

### DIFF
--- a/src/about.html
+++ b/src/about.html
@@ -9,7 +9,11 @@
     <link rel="stylesheet" href="../assets/css/about.css">
     <script src="about.js"></script>
     <script src="helpers.js"></script>
-    <script>const workstation = require('./chef_workstation.js');</script>
+    <script>
+      document.addEventListener("DOMContentLoaded", function(event) { 
+        updateDialog();
+      });
+    </script>
   </head>
   <body>
     <main>
@@ -23,8 +27,9 @@
               </script>
             </p>
             <div class="p-inline-button">
+              <!-- workstation is available via the about.js script -->
               <p id='update-channel'><strong>Release</strong> <script>document.write(workstation.getUpdateChannel())</script></p>
-              <button disabled class="secondary">Switch to current release</button>
+              <button id='update-channel-btn' class="secondary" onclick="toggleUpdatesChannel()" disabled>Switch to <script>document.write(getSwitchToChannel())</script> release</button>
               <button class="info"></button>
             </div>
           </div>

--- a/src/about.js
+++ b/src/about.js
@@ -1,35 +1,9 @@
-const { shell, BrowserWindow } = require('electron');
+const { shell } = require('electron');
 const path = require('path');
 const helpers = require('./helpers.js');
-
-const width = process.platform === 'darwin' ? 510 : 530;
-const height = process.platform === 'darwin' ? 325 : 330;
-
-let aboutDialog = null;
-
-function open() {
-  if (aboutDialog == null) {
-    let aboutPath = path.join('file://', __dirname, 'about.html');
-    aboutDialog = new BrowserWindow({
-      show: false,
-      width: width,
-      height: height,
-      resizable: false,
-      minimizable: false,
-      maximizable: false
-    });
-    aboutDialog.loadURL(aboutPath);
-    aboutDialog.once('ready-to-show', () => {
-      aboutDialog.show()
-    });
-    aboutDialog.on('closed', () => {
-      aboutDialog = null;
-    });
-  } else {
-    // Bring to front if open.
-    aboutDialog.focus();
-  }
-}
+// This is some magic to get the same module as the one loaded in the main process
+// so that our caches are the same.
+const workstation = require('electron').remote.require('./src/chef_workstation.js');
 
 // We open all these links in the users default browser (or what they have setup by default to open HTML).
 // We purposefully decided to open it in the system browser instead of a build in Electron window because
@@ -50,4 +24,24 @@ function openPackageDetails() {
   shell.openExternal(detailsPath)
 }
 
-module.exports.open = open;
+function getSwitchToChannel() {
+   let channel = workstation.getUpdateChannel();
+   if (channel == 'stable') {
+     return 'current';
+   } else {
+     return 'stable';
+   }
+}
+
+function toggleUpdatesChannel() {
+  workstation.setUpdateChannel(getSwitchToChannel());
+  updateDialog();
+  const app = require('electron').remote.app;
+  app.emit('do-update-check', true, false);
+}
+
+function updateDialog() {
+  document.getElementById('update-channel-btn').disabled = !(workstation.areUpdatesEnabled() && workstation.canUpdateChannel());
+  document.getElementById('update-channel-btn').textContent = 'Switch to ' + getSwitchToChannel() + ' channel';
+  document.getElementById('update-channel').innerHTML = '<strong>Release</strong> ' + workstation.getUpdateChannel();
+}

--- a/src/about_dialog.js
+++ b/src/about_dialog.js
@@ -1,0 +1,33 @@
+const { BrowserWindow } = require('electron');
+const path = require('path');
+
+const width = process.platform === 'darwin' ? 510 : 530;
+const height = process.platform === 'darwin' ? 325 : 330;
+
+let aboutDialog = null;
+
+function open() {
+  if (aboutDialog == null) {
+    let aboutPath = path.join('file://', __dirname, 'about.html');
+    aboutDialog = new BrowserWindow({
+      show: false,
+      width: width,
+      height: height,
+      resizable: false,
+      minimizable: false,
+      maximizable: false
+    });
+    aboutDialog.loadURL(aboutPath);
+    aboutDialog.once('ready-to-show', () => {
+      aboutDialog.show()
+    });
+    aboutDialog.on('closed', () => {
+      aboutDialog = null;
+    });
+  } else {
+    // Bring to front if open.
+    aboutDialog.focus();
+  }
+}
+
+module.exports.open = open;

--- a/src/chef_workstation.js
+++ b/src/chef_workstation.js
@@ -4,6 +4,7 @@
  * (of which this app is a component)
  */
 
+const { app } = require('electron');
 const os = require('os')
 const path = require('path');
 const fs = require('fs');
@@ -18,8 +19,14 @@ const { execFileSync } = require('child_process');
 
 const registryCache = {};
 
-const userConfigFile = path.join(os.homedir(), '/.chef-workstation/config.toml');
+const ws_dir = path.join(os.homedir(), '/.chef_workstation');
+const userConfigFile = path.join(ws_dir, '/config.toml');
+const appConfigFile = path.join(ws_dir, '/.app-managed-config.toml');
 let userConfigCache = null;
+let appConfigCache = null;
+let loadedAppConfig = null;
+
+let userConfigFileWatcher = null;
 
 function syncGetRegistryValue(baseKey, key, type = "REG_SZ") {
   var cacheKey = baseKey+key+type;
@@ -117,6 +124,32 @@ function getUserConfig() {
   return userConfigCache;
 }
 
+function getAppConfig() {
+  if (loadedAppConfig == null && appConfigCache == null) {
+    try {
+      loadedAppConfig = TOML.parse(fs.readFileSync(appConfigFile));
+      appConfigCache = loadedAppConfig;
+    } catch(error) {
+      appConfigCache = {};
+    }
+  }
+  return appConfigCache;
+}
+
+function saveAppConfig() {
+  if ((loadedAppConfig != null && appConfigCache != null) || (loadedAppConfig == null && appConfigCache != {})) {
+    try {
+      if (!fs.existsSync(ws_dir)) {
+        fs.mkdirSync(ws_dir);
+      }
+      fs.writeFileSync(appConfigFile, TOML.stringify(appConfigCache));
+    } catch(error) {
+      // Something went wrong can't persist values so when user restarts they'll be back to defaults.
+    }
+    loadedAppConfig = appConfigCache;
+  }
+}
+
 function areUpdatesEnabled() {
   let userConfig = getUserConfig();
   if (userConfig.updates == undefined || userConfig.updates.enable == undefined) {
@@ -138,10 +171,37 @@ function getUpdateIntervalMinutes() {
 function getUpdateChannel() {
   let userConfig = getUserConfig();
   if (userConfig.updates == undefined || userConfig.updates.channel == undefined) {
-    return 'stable';
+    let appConfig = getAppConfig();
+    if (appConfig.updates == undefined || appConfig.updates.channel == undefined) {
+      return 'stable';
+    } else {
+      return appConfig.updates.channel;
+    }
   } else {
     return userConfig.updates.channel;
   }
+}
+
+function canUpdateChannel() {
+  let userConfig = getUserConfig();
+  if (userConfig.updates == undefined || userConfig.updates.channel == undefined) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+function setUpdateChannel(channel) {
+  let appConfig = getAppConfig();
+  if (appConfig == null) {
+    appConfig = {};
+  }
+  if (appConfig.updates == undefined) {
+    appConfig.updates = { 'channel': channel };
+  } else {
+    appConfig.updates.channel = channel;
+  }
+  saveAppConfig();
 }
 
 module.exports.getVersion = getVersion;
@@ -149,5 +209,7 @@ module.exports.getPlatformInfo = getPlatformInfo;
 
 // Config functions
 module.exports.areUpdatesEnabled = areUpdatesEnabled;
+module.exports.canUpdateChannel = canUpdateChannel;
 module.exports.getUpdateIntervalMinutes = getUpdateIntervalMinutes;
 module.exports.getUpdateChannel = getUpdateChannel;
+module.exports.setUpdateChannel = setUpdateChannel;

--- a/src/no_update.html
+++ b/src/no_update.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="../assets/css/no_update.css">
     <script src="helpers.js"></script>
     <script src="no_update.js"></script>
-    <script>const workstation = require('./chef_workstation.js');</script>
+    <script>const workstation = require('electron').remote.require('./src/chef_workstation.js');</script>
   </head>
   <body>
     <div class="top-panel">

--- a/src/update_available.html
+++ b/src/update_available.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="../assets/css/update_available.css">
     <script src="helpers.js"></script>
     <script src="update_available.js"></script>
-    <script>const workstation = require('./chef_workstation.js');</script>
+    <script>const workstation = require('electron').remote.require('./src/chef_workstation.js');</script>
     <script>
       var electron = require('electron');
       var currentWindow = electron.remote.getCurrentWindow();

--- a/src/ws_tray.js
+++ b/src/ws_tray.js
@@ -6,7 +6,7 @@ const { app, Tray } = require('electron');
 const path = require('path');
 const is = require('electron-is');
 const osxPrefs = require('electron-osx-appearance');
-const chefWorkstation = require('./chef_workstation.js')
+const workstation = require('./chef_workstation.js')
 const util = require('util');
 
 // private
@@ -40,7 +40,7 @@ function WSTray() {
     }
     isNotifying = false;
     setToolTip();
-    setVersion(chefWorkstation.getVersion());
+    setVersion(workstation.getVersion());
 }
 
 function setNotifyIcon() {


### PR DESCRIPTION
This change makes the update channel button on the
about dialog work. It introduces a new app manged
config file where the selected channel is persisted.
The button is disabled if the user has set a channel
in the user config file and that value will be used.

Signed-off-by: Jon Morrow <jmorrow@chef.io>