### PR TITLE
[SHACK-377] User config file listener

### DIFF
--- a/assets/css/about.css
+++ b/assets/css/about.css
@@ -48,3 +48,7 @@ a p:parent {
 section.link-list p:not(:last-child) {
   margin-bottom: 20px;
 }
+
+#update-channel {
+  text-transform: capitalize;
+}

--- a/main.js
+++ b/main.js
@@ -90,7 +90,7 @@ function startApp() {
   // Do first check and setup update checks.
   if (workstation.areUpdatesEnabled()) {
     triggerUpdateCheck();
-    let minutes = 60*8; // Every 8 hours.
+    let minutes = workstation.getUpdateIntervalMinutes();
     updateCheckInterval = setInterval(triggerUpdateCheck, minutes*60*1000);
   }
 }

--- a/main.js
+++ b/main.js
@@ -104,9 +104,11 @@ function startApp() {
     triggerUpdateCheck();
     setupUpdateInterval();
   }
+  workstation.startWatchingConfig();
 }
 
 function quitApp() {
+  workstation.stopWatchingConfig();
   clearUpdateInterval();
   backgroundWindow = null;
   app.quit();
@@ -156,6 +158,18 @@ mixlibInstallUpdater.on('end-update-check', () => {
 app.on('do-update-check', (_requestFromUser) => {
   requestFromUser = _requestFromUser;
   mixlibInstallUpdater.checkForUpdates(workstation.getVersion());
+});
+
+app.on('user-config-update', () => {
+  if (workstation.areUpdatesEnabled()) {
+    if (updateCheckTimeInterval != workstation.getUpdateIntervalMinutes()) {
+      clearUpdateInterval();
+      triggerUpdateCheck();
+      setupUpdateInterval();
+    }
+  } else if (updateCheckInterval != null) {
+    clearUpdateInterval();
+  }
 });
 
 app.on('ready', () => {

--- a/src/about.html
+++ b/src/about.html
@@ -23,7 +23,7 @@
               </script>
             </p>
             <div class="p-inline-button">
-              <p><strong>Release</strong> <script>document.write(getReleaseChannel())</script></p>
+              <p id='update-channel'><strong>Release</strong> <script>document.write(workstation.getUpdateChannel())</script></p>
               <button disabled class="secondary">Switch to current release</button>
               <button class="info"></button>
             </div>

--- a/src/about.html
+++ b/src/about.html
@@ -9,7 +9,11 @@
     <link rel="stylesheet" href="../assets/css/about.css">
     <script src="about.js"></script>
     <script src="helpers.js"></script>
-    <script>const workstation = require('./chef_workstation.js');</script>
+    <script>
+      document.addEventListener("DOMContentLoaded", function(event) { 
+        updateDialog();
+      });
+    </script>
   </head>
   <body>
     <main>
@@ -23,8 +27,9 @@
               </script>
             </p>
             <div class="p-inline-button">
+              <!-- workstation is available via the about.js script -->
               <p id='update-channel'><strong>Release</strong> <script>document.write(workstation.getUpdateChannel())</script></p>
-              <button disabled class="secondary">Switch to current release</button>
+              <button id='update-channel-btn' class="secondary" onclick="toggleUpdatesChannel()" disabled>Switch to <script>document.write(getSwitchToChannel())</script> release</button>
               <button class="info"></button>
             </div>
           </div>

--- a/src/about.js
+++ b/src/about.js
@@ -1,35 +1,9 @@
-const { shell, BrowserWindow } = require('electron');
+const { shell } = require('electron');
 const path = require('path');
 const helpers = require('./helpers.js');
-
-const width = process.platform === 'darwin' ? 510 : 530;
-const height = process.platform === 'darwin' ? 325 : 330;
-
-let aboutDialog = null;
-
-function open() {
-  if (aboutDialog == null) {
-    let aboutPath = path.join('file://', __dirname, 'about.html');
-    aboutDialog = new BrowserWindow({
-      show: false,
-      width: width,
-      height: height,
-      resizable: false,
-      minimizable: false,
-      maximizable: false
-    });
-    aboutDialog.loadURL(aboutPath);
-    aboutDialog.once('ready-to-show', () => {
-      aboutDialog.show()
-    });
-    aboutDialog.on('closed', () => {
-      aboutDialog = null;
-    });
-  } else {
-    // Bring to front if open.
-    aboutDialog.focus();
-  }
-}
+// This is some magic to get the same module as the one loaded in the main process
+// so that our caches are the same.
+const workstation = require('electron').remote.require('./src/chef_workstation.js');
 
 // We open all these links in the users default browser (or what they have setup by default to open HTML).
 // We purposefully decided to open it in the system browser instead of a build in Electron window because
@@ -50,4 +24,24 @@ function openPackageDetails() {
   shell.openExternal(detailsPath)
 }
 
-module.exports.open = open;
+function getSwitchToChannel() {
+   let channel = workstation.getUpdateChannel();
+   if (channel == 'stable') {
+     return 'current';
+   } else {
+     return 'stable';
+   }
+}
+
+function toggleUpdatesChannel() {
+  workstation.setUpdateChannel(getSwitchToChannel());
+  updateDialog();
+  const app = require('electron').remote.app;
+  app.emit('do-update-check', true, false);
+}
+
+function updateDialog() {
+  document.getElementById('update-channel-btn').disabled = !(workstation.areUpdatesEnabled() && workstation.canUpdateChannel());
+  document.getElementById('update-channel-btn').textContent = 'Switch to ' + getSwitchToChannel() + ' channel';
+  document.getElementById('update-channel').innerHTML = '<strong>Release</strong> ' + workstation.getUpdateChannel();
+}

--- a/src/about_dialog.js
+++ b/src/about_dialog.js
@@ -1,0 +1,33 @@
+const { BrowserWindow } = require('electron');
+const path = require('path');
+
+const width = process.platform === 'darwin' ? 510 : 530;
+const height = process.platform === 'darwin' ? 325 : 330;
+
+let aboutDialog = null;
+
+function open() {
+  if (aboutDialog == null) {
+    let aboutPath = path.join('file://', __dirname, 'about.html');
+    aboutDialog = new BrowserWindow({
+      show: false,
+      width: width,
+      height: height,
+      resizable: false,
+      minimizable: false,
+      maximizable: false
+    });
+    aboutDialog.loadURL(aboutPath);
+    aboutDialog.once('ready-to-show', () => {
+      aboutDialog.show()
+    });
+    aboutDialog.on('closed', () => {
+      aboutDialog = null;
+    });
+  } else {
+    // Bring to front if open.
+    aboutDialog.focus();
+  }
+}
+
+module.exports.open = open;

--- a/src/chef_workstation.js
+++ b/src/chef_workstation.js
@@ -135,9 +135,19 @@ function getUpdateIntervalMinutes() {
   }
 }
 
+function getUpdateChannel() {
+  let userConfig = getUserConfig();
+  if (userConfig.updates == undefined || userConfig.updates.channel == undefined) {
+    return 'stable';
+  } else {
+    return userConfig.updates.channel;
+  }
+}
+
 module.exports.getVersion = getVersion;
 module.exports.getPlatformInfo = getPlatformInfo;
 
 // Config functions
 module.exports.areUpdatesEnabled = areUpdatesEnabled;
 module.exports.getUpdateIntervalMinutes = getUpdateIntervalMinutes;
+module.exports.getUpdateChannel = getUpdateChannel;

--- a/src/chef_workstation.js
+++ b/src/chef_workstation.js
@@ -126,8 +126,18 @@ function areUpdatesEnabled() {
   }
 }
 
+function getUpdateIntervalMinutes() {
+  let userConfig = getUserConfig();
+  if (userConfig.updates == undefined || userConfig.updates.interval_minutes == undefined) {
+    return 60*8; // Every 8 hours.
+  } else {
+    return userConfig.updates.interval_minutes;
+  }
+}
+
 module.exports.getVersion = getVersion;
 module.exports.getPlatformInfo = getPlatformInfo;
 
 // Config functions
 module.exports.areUpdatesEnabled = areUpdatesEnabled;
+module.exports.getUpdateIntervalMinutes = getUpdateIntervalMinutes;

--- a/src/chef_workstation.js
+++ b/src/chef_workstation.js
@@ -204,6 +204,30 @@ function setUpdateChannel(channel) {
   saveAppConfig();
 }
 
+function handleUserConfigFileEvent() {
+  try {
+    userConfigCache = TOML.parse(fs.readFileSync(userConfigFile));
+    app.emit('user-config-update');
+  } catch(error) {
+    // Fail silently if the file doesn't exist or is otherwise unreadable.
+  }
+}
+
+function startWatchingConfig() {
+  if (userConfigFileWatcher == null) {
+    try {
+      userConfigFileWatcher = fs.watchFile(userConfigFile, handleUserConfigFileEvent);
+    } catch(error) {
+      // Fail silently if the file doesn't exist or is otherwise unreadable.
+    }
+  }
+}
+
+function stopWatchingConfig() {
+  fs.unwatchFile(userConfigFile);
+  userConfigFileWatcher = null;
+}
+
 module.exports.getVersion = getVersion;
 module.exports.getPlatformInfo = getPlatformInfo;
 
@@ -213,3 +237,5 @@ module.exports.canUpdateChannel = canUpdateChannel;
 module.exports.getUpdateIntervalMinutes = getUpdateIntervalMinutes;
 module.exports.getUpdateChannel = getUpdateChannel;
 module.exports.setUpdateChannel = setUpdateChannel;
+module.exports.startWatchingConfig = startWatchingConfig;
+module.exports.stopWatchingConfig = stopWatchingConfig;

--- a/src/chef_workstation.js
+++ b/src/chef_workstation.js
@@ -4,6 +4,7 @@
  * (of which this app is a component)
  */
 
+const { app } = require('electron');
 const os = require('os')
 const path = require('path');
 const fs = require('fs');
@@ -18,8 +19,14 @@ const { execFileSync } = require('child_process');
 
 const registryCache = {};
 
-const userConfigFile = path.join(os.homedir(), '/.chef-workstation/config.toml');
+const ws_dir = path.join(os.homedir(), '/.chef_workstation');
+const userConfigFile = path.join(ws_dir, '/config.toml');
+const appConfigFile = path.join(ws_dir, '/.app-managed-config.toml');
 let userConfigCache = null;
+let appConfigCache = null;
+let loadedAppConfig = null;
+
+let userConfigFileWatcher = null;
 
 function syncGetRegistryValue(baseKey, key, type = "REG_SZ") {
   var cacheKey = baseKey+key+type;
@@ -117,6 +124,32 @@ function getUserConfig() {
   return userConfigCache;
 }
 
+function getAppConfig() {
+  if (loadedAppConfig == null && appConfigCache == null) {
+    try {
+      loadedAppConfig = TOML.parse(fs.readFileSync(appConfigFile));
+      appConfigCache = loadedAppConfig;
+    } catch(error) {
+      appConfigCache = {};
+    }
+  }
+  return appConfigCache;
+}
+
+function saveAppConfig() {
+  if ((loadedAppConfig != null && appConfigCache != null) || (loadedAppConfig == null && appConfigCache != {})) {
+    try {
+      if (!fs.existsSync(ws_dir)) {
+        fs.mkdirSync(ws_dir);
+      }
+      fs.writeFileSync(appConfigFile, TOML.stringify(appConfigCache));
+    } catch(error) {
+      // Something went wrong can't persist values so when user restarts they'll be back to defaults.
+    }
+    loadedAppConfig = appConfigCache;
+  }
+}
+
 function areUpdatesEnabled() {
   let userConfig = getUserConfig();
   if (userConfig.updates == undefined || userConfig.updates.enable == undefined) {
@@ -138,10 +171,37 @@ function getUpdateIntervalMinutes() {
 function getUpdateChannel() {
   let userConfig = getUserConfig();
   if (userConfig.updates == undefined || userConfig.updates.channel == undefined) {
-    return 'stable';
+    let appConfig = getAppConfig();
+    if (appConfig.updates == undefined || appConfig.updates.channel == undefined) {
+      return 'stable';
+    } else {
+      return appConfig.updates.channel;
+    }
   } else {
     return userConfig.updates.channel;
   }
+}
+
+function canUpdateChannel() {
+  let userConfig = getUserConfig();
+  if (userConfig.updates == undefined || userConfig.updates.channel == undefined) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+function setUpdateChannel(channel) {
+  let appConfig = getAppConfig();
+  if (appConfig == null) {
+    appConfig = {};
+  }
+  if (appConfig.updates == undefined) {
+    appConfig.updates = { 'channel': channel };
+  } else {
+    appConfig.updates.channel = channel;
+  }
+  saveAppConfig();
 }
 
 module.exports.getVersion = getVersion;
@@ -149,5 +209,7 @@ module.exports.getPlatformInfo = getPlatformInfo;
 
 // Config functions
 module.exports.areUpdatesEnabled = areUpdatesEnabled;
+module.exports.canUpdateChannel = canUpdateChannel;
 module.exports.getUpdateIntervalMinutes = getUpdateIntervalMinutes;
 module.exports.getUpdateChannel = getUpdateChannel;
+module.exports.setUpdateChannel = setUpdateChannel;

--- a/src/mixlib_install_updater.js
+++ b/src/mixlib_install_updater.js
@@ -2,6 +2,7 @@ const events = require('events');
 const isVersionGreaterThan = require('semver').gt;
 const request = require('request');
 const util = require('util'); // formatting
+const workstation = require('./chef_workstation.js');
 const OMNITRUCK_URL = "https://omnitruck.chef.io/%s/chef-workstation/metadata/?p=%s&pv=%s&v=%s&m=%s&prerelease=false&nightlies=false";
 let _platformInfo = null;
 
@@ -11,8 +12,8 @@ function MixlibInstallUpdater() {
 
 function checkForUpdates(currentVersion) {
   this.emit('start-update-check');
+  let _channel = workstation.getUpdateChannel();
   if (_platformInfo == null) {
-    const workstation = require('./chef_workstation.js');
     _platformInfo = workstation.getPlatformInfo();
     
     if (_platformInfo == null) {
@@ -22,7 +23,7 @@ function checkForUpdates(currentVersion) {
     }
   }
 
-  let url = util.format(OMNITRUCK_URL, "stable", _platformInfo.platform, _platformInfo.platform_version
+  let url = util.format(OMNITRUCK_URL, _channel, _platformInfo.platform, _platformInfo.platform_version
     , "latest", _platformInfo.kernel_machine);
   request(url, { json: true }, (err, res, body) => {
     if (err)  {

--- a/src/no_update.html
+++ b/src/no_update.html
@@ -17,7 +17,7 @@
         </div>
         <div>
           <script>document.write(workstation.getVersion())</script> is the latest
-          <script>document.write(getReleaseChannel())</script> release available.
+          <script>document.write(workstation.getUpdateChannel())</script> release available.
         </div>
       </div>
     </div>

--- a/src/no_update.html
+++ b/src/no_update.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="../assets/css/no_update.css">
     <script src="helpers.js"></script>
     <script src="no_update.js"></script>
-    <script>const workstation = require('./chef_workstation.js');</script>
+    <script>const workstation = require('electron').remote.require('./src/chef_workstation.js');</script>
   </head>
   <body>
     <div class="top-panel">

--- a/src/update_available.html
+++ b/src/update_available.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="../assets/css/update_available.css">
     <script src="helpers.js"></script>
     <script src="update_available.js"></script>
-    <script>const workstation = require('./chef_workstation.js');</script>
+    <script>const workstation = require('electron').remote.require('./src/chef_workstation.js');</script>
     <script>
       var electron = require('electron');
       var currentWindow = electron.remote.getCurrentWindow();

--- a/src/update_available.html
+++ b/src/update_available.html
@@ -24,7 +24,7 @@
             document.write(updateInfo.version)
           </script>
           is the latest
-          <script>document.write(getReleaseChannel())</script>
+          <script>document.write(workstation.getUpdateChannel())</script>
           release, you have
           <script>document.write(workstation.getVersion())</script>.
         </div>

--- a/src/ws_tray.js
+++ b/src/ws_tray.js
@@ -6,7 +6,7 @@ const { app, Tray } = require('electron');
 const path = require('path');
 const is = require('electron-is');
 const osxPrefs = require('electron-osx-appearance');
-const chefWorkstation = require('./chef_workstation.js')
+const workstation = require('./chef_workstation.js')
 const util = require('util');
 
 // private
@@ -40,7 +40,7 @@ function WSTray() {
     }
     isNotifying = false;
     setToolTip();
-    setVersion(chefWorkstation.getVersion());
+    setVersion(workstation.getVersion());
 }
 
 function setNotifyIcon() {


### PR DESCRIPTION
This change adds a file listener so when a user makes changes
to their config file the app can know about them and update/cancel
update checks/channel.

Signed-off-by: Jon Morrow <jmorrow@chef.io>