### PR TITLE
[SHACK-321] Check for updates / Download menu item

### DIFF
--- a/src/update_available.html
+++ b/src/update_available.html
@@ -9,7 +9,6 @@
     <script>const workstation = require('electron').remote.require('./src/chef_workstation.js');</script>
     <script>
       var electron = require('electron');
-      var currentWindow = electron.remote.getCurrentWindow();
     </script>
   </head>
   <body>

--- a/src/update_available.js
+++ b/src/update_available.js
@@ -1,14 +1,10 @@
-const { remote, shell }  = require('electron');
-const updateAvailableWindow = remote.getCurrentWindow();
-const updateInfo = updateAvailableWindow.updateInfo;
+const app = require('electron').remote.app;
 
 function closeDialog() {
   window.close();
 }
 
 function downloadUpdate() {
-  let result = shell.openExternal(updateInfo.url);
-
-  console.log("Attempted to open URL: " + updateInfo.url + ". Result: " + result);
+  app.emit('do-download');
   updateAvailableWindow.close();
 }

--- a/src/update_available_dialog.js
+++ b/src/update_available_dialog.js
@@ -3,7 +3,7 @@ const path = require('path');
 
 let updateAvailableDialog = null;
 
-function open(updateInfo, workstationVersion) {
+function open() {
   if (updateAvailableDialog == null) {
     const updateAvailablePath = path.join('file://', __dirname, 'update_available.html');
     updateAvailableDialog = new BrowserWindow({
@@ -25,8 +25,6 @@ function open(updateInfo, workstationVersion) {
       updateAvailableDialog = null;
     });
     workstationInfo = require('./chef_workstation.js');
-    updateAvailableDialog.updateInfo = updateInfo;
-    updateAvailableDialog.workstationVersion = workstationVersion;
   }
 }
 


### PR DESCRIPTION
This change updates the 'Check for updates...' menu item to 'Download update vX.X.X' whent updates area vailable. It also changes downloads to be driven via events.

Signed-off-by: Jon Morrow <jmorrow@chef.io>