### PR TITLE
update repo to new Chef OSS practices

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Chef Workstation Tray Application
 
+**Umbrella Project**: [Workstation](https://github.com/chef/chef-oss-practices/blob/master/projects/chef-workstation.md)
+
+* **[Project State](https://github.com/chef/chef-oss-practices/blob/master/repo-management/repo-states.md):** Active
+* **Issues [Response Time Maximum](https://github.com/chef/chef-oss-practices/blob/master/repo-management/repo-states.md):** 14 days
+* **Pull Request [Response Time Maximum](https://github.com/chef/chef-oss-practices/blob/master/repo-management/repo-states.md):** 14 days
+
 This the the tray application for Chef Workstation. It's written in Electron and
 will be where we implement any UI based features of Chef Workstation.
 


### PR DESCRIPTION
## Description

In accordance with https://github.com/chef/chef-oss-practices/blob/master/repo-management/repo-states.md

* update README with project state and response times