### PR TITLE
[bug-fix] Enforce settings on trigger update func

### DIFF
--- a/src/about.js
+++ b/src/about.js
@@ -78,7 +78,9 @@ function getSwitchToChannel() {
 function toggleUpdatesChannel() {
   appConfig.default.setUpdateChannel(getSwitchToChannel());
   updateDialog();
-  ipcRenderer.send('do-update-check', true, false);
+  // TODO @afiune Enforce the type TriggerUpdateSettings here when we move to typescript
+  // why? because javascript can't do the enforcement
+  ipcRenderer.send('do-update-check', { UserRequest: true, DisplayUpdateNotAvailableDialog: false});
 }
 
 function updateDialog() {


### PR DESCRIPTION
## Description

There was a bug in the `do-update-check` event, before we were not
passing the settings/parameters to the underlying function, we were
actually just ignoring them, now we are passing them through an
interface that encapsulates them and enforces them.

Signed-off-by: Salim Afiune <afiune@chef.io>

Here is a quick gift of the new behavior:
![bug](https://user-images.githubusercontent.com/5712253/64896907-b2f18580-d63e-11e9-9d79-9825dff4f462.gif)

Not sure if it is clear but before this change we were not able to see the "Update Available Dialog" Window. Now we trigger that automatically when we switch the release channel.

## Related Issue
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
