### PR TITLE
Switch mac compression from zip to .tar.gz

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -18,7 +18,7 @@ extraResources:
   - "assets/"
 
 mac:
-  target: ["zip"]
+  target: ["tar.xz"]
   category: "public.app-category.developer-tools"
   icon: "assets/images/logo.png"
   extendInfo:


### PR DESCRIPTION
zip is a pretty awful compression format are results in a 61.6 meg artifact vs. 44.2 megs for tar.gz, which is a 28% drop in file size. Overall it should have a pretty minimal install size change as well:

```
time unzip Chef\ Workstation\ App-0.1.23-mac.zip

        1.19 real         0.96 user         0.13 sys

time tar -xzf Chef\ Workstation\ App-0.1.23-mac.tar.xz
        2.45 real         2.31 user         0.13 sys
```

Signed-off-by: Tim Smith <tsmith@chef.io>