### PR TITLE
Fix the scrollbar showing up in the about window

### DIFF
--- a/assets/css/about.css
+++ b/assets/css/about.css
@@ -1,11 +1,15 @@
 main {
-  margin: 20px 22px;
+  margin: 20px 22px 10px;
 }
 
 section {
   display: inline-block;
   width: 100%;
   margin-bottom: 20px;
+}
+
+section.footer {
+  margin-bottom: 0px;
 }
 
 button.secondary {

--- a/src/about-dialog/about.html
+++ b/src/about-dialog/about.html
@@ -47,7 +47,7 @@
         <p><a href="javascript:about.openLicense();">License Agreement</a></p>
         <p><a href="javascript:about.openReleaseNotes();">Release notes</a></p>
       </section>
-      <section>
+      <section class="footer">
         <p class="small">&#9400; 2008-2019 Chef Software, Inc. All Rights Reserved.</p>
       </section>
     </main>


### PR DESCRIPTION
When we moved the contents of this window around we made it slightly too large for the window which results in the scroll bar showing. section has a 20px botton margin which was also being applied below the copyright information. We don't need a margin below this content and that margin was resulting in the scroll bar showing. I added a footer class with a 0px margin since it's the last thing on the window and the margin doesn't matter there. I also added a 10px bottom margin (instead of 20px) to main.

Before:
<img width="622" alt="Screen Shot 2019-11-01 at 5 29 53 PM" src="https://user-images.githubusercontent.com/1015200/68063374-93391e00-fccd-11e9-90e0-7220a6c7ad05.png">

After:
<img width="578" alt="Screen Shot 2019-11-01 at 5 30 45 PM" src="https://user-images.githubusercontent.com/1015200/68063380-9a602c00-fccd-11e9-9c34-5d4660169813.png">

Signed-off-by: Tim Smith <tsmith@chef.io>