### PR TITLE
Detect dark mode using Electron 7 natively

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -634,8 +634,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/boolean/-/boolean-2.0.3.tgz",
       "integrity": "sha512-iHzXeFCXWrpjYE7DToXGCBPGZf0eVISqzL+4sgrOSYEKXnb59WHPFvGTTyCj6zJ/MuuLAxEn8zPkrTHHzlt3IA==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "boxen": {
       "version": "3.2.0",
@@ -1279,7 +1278,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
@@ -1880,11 +1879,6 @@
         "keyboardevents-areequal": "^0.2.1"
       }
     },
-    "electron-osx-appearance": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/electron-osx-appearance/-/electron-osx-appearance-0.1.1.tgz",
-      "integrity": "sha1-Kk5fp10X69p33DGx/CESHEHLeaE="
-    },
     "electron-publish": {
       "version": "21.2.0",
       "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-21.2.0.tgz",
@@ -2203,7 +2197,7 @@
       "dependencies": {
         "combined-stream": {
           "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+          "resolved": "http://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
           "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
           "requires": {
             "delayed-stream": "~1.0.0"
@@ -3229,7 +3223,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         }
@@ -3342,7 +3336,7 @@
       "dependencies": {
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "@iarna/toml": "^2.2.3",
     "electron-debug": "^3.0.1",
     "electron-is": "^3.0.0",
-    "electron-osx-appearance": "^0.1.1",
     "request": "^2.0.0"
   }
 }

--- a/src/ws_tray.js
+++ b/src/ws_tray.js
@@ -84,6 +84,13 @@ function setToolTip() {
     tray.setToolTip(updateAvailable ? toolTip + "Update Available" : toolTip + "Up to date");
 };
 
+function subscribeThemeChangeMacOS() {
+  tray.subscribeNotification(
+    'AppleInterfaceThemeChangedNotification',
+    displayNotification(isNotifying)
+  );
+};
+
 // Expose Public WSTray instance funcitons.
 WSTray.prototype.displayNotification = displayNotification;
 WSTray.prototype.setContextMenu = setContextMenu;
@@ -109,8 +116,5 @@ app.on('ready', () => {
 
   // Not sure about this pattern... Maybe this should live in main?
   // Subscribe to changes to dark mode setting so we can update the icon.
-  self.subscribeNotification(
-    'AppleInterfaceThemeChangedNotification',
-    displayNotification(isNotifying)
-  )
+  subscribeThemeChangeMacOS;
 });

--- a/src/ws_tray.js
+++ b/src/ws_tray.js
@@ -5,7 +5,6 @@
 const { app, Tray } = require('electron');
 const path = require('path');
 const is = require('electron-is');
-const osxPrefs = require('electron-osx-appearance');
 const workstation = require('./helpers/chef_workstation.js')
 const util = require('util');
 
@@ -23,7 +22,7 @@ const winIcon = path.join(__dirname, '../assets/images/iconLightTemplate@3x.png'
 const winIconNotify = path.join(__dirname, '../assets/images/iconLightNotify@3x.png');
 
 // Default icon
-var icon = is.osx() ? macIcon : winIcon;
+var icon = is.macOS() ? macIcon : winIcon;
 
 // Electron Tray
 var tray = null;
@@ -35,7 +34,7 @@ var version = "[unknown]";
 
 function WSTray() {
     tray = new Tray(icon);
-    if (is.osx()) {
+    if (is.macOS()) {
       app.dock.hide()
     }
     isNotifying = false;
@@ -44,8 +43,8 @@ function WSTray() {
 }
 
 function setNotifyIcon() {
-    if (is.osx()) {
-        if (osxPrefs.isDarkMode()) {
+    if (is.macOS()) {
+        if (tray.remote.systemPreferences.isDarkMode()) {
             tray.setImage(macIconLightNotify);
         } else {
             tray.setImage(macIconDarkNotify);
@@ -103,14 +102,15 @@ var self = module.exports = {
     }
 }
 
-// Not sure about this pattern... Maybe this should live in main?
-// Subscribe to changes to dark mode setting so we can update the icon.
-if (is.osx()) {
-    osxPrefs.onDarkModeChanged(() => {
-        displayNotification(isNotifying);
-    });
-}
-
 // Not sure about this pattern but it makes sure we have an instance
 // as soon as the app starts.
-app.on('ready', () => { self.instance(); });
+app.on('ready', () => {
+  self.instance();
+
+  // Not sure about this pattern... Maybe this should live in main?
+  // Subscribe to changes to dark mode setting so we can update the icon.
+  self.subscribeNotification(
+    'AppleInterfaceThemeChangedNotification',
+    displayNotification(isNotifying)
+  )
+});


### PR DESCRIPTION
Remove the dep on electron-osx-appearance. I also switched to is.macOS not the alias of is.osx

Signed-off-by: Tim Smith <tsmith@chef.io>