### PR TITLE
Only ship english lang files since that's all we have

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -21,6 +21,7 @@ mac:
   target: ["zip"]
   category: "public.app-category.developer-tools"
   icon: "assets/images/logo.png"
+  electronLanguages: ["en"]
   extendInfo:
     LSUIElement: 1
 


### PR DESCRIPTION
At the moment we don't have any localized files so we shouldn't ship
anything other than en. This doesn't actually reduce file size since there was nothing in the files, but it reduces the number of empty dirs in the mac artifact by 52

Signed-off-by: Tim Smith <tsmith@chef.io>