### PR TITLE
Update how we check for dark mode

### DIFF
--- a/src/ws_tray.js
+++ b/src/ws_tray.js
@@ -2,7 +2,7 @@
 /*
 * WSTray module handles toggling the state/image of our tray icon.
 */
-const { app, Tray, systemPreferences } = require('electron');
+const { app, Tray, nativeTheme } = require('electron');
 const path = require('path');
 const is = require('electron-is');
 const workstation = require('./helpers/chef_workstation.js')
@@ -44,7 +44,7 @@ function WSTray() {
 
 function setNotifyIcon() {
     if (is.macOS()) {
-        if (systemPreferences.isDarkMode()) {
+        if (nativeTheme.shouldUseDarkColors) {
             tray.setImage(macIconLightNotify);
         } else {
             tray.setImage(macIconDarkNotify);


### PR DESCRIPTION
This is the preferred way to perform this check in Electron now and resolves a deprecation warning that was being thrown.

Signed-off-by: Tim Smith <tsmith@chef.io>