### PR TITLE
launcher:(script) remove nounset option

### DIFF
--- a/assets/scripts/chef_workstation_app_launcher
+++ b/assets/scripts/chef_workstation_app_launcher
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-set -eou pipefail
+set -eo pipefail
 
 PROGNAME=$(basename "$0")
 PRODUCTNAME="Chef Workstation App"


### PR DESCRIPTION
## Description
When running this script with `su` we have an error message:
```
Salims-MBP:~ root# su "$SUDO_USER" /opt/chef-workstation/bin/chef_workstation_app_launcher load
/opt/chef-workstation/bin/chef_workstation_app_launcher:set:20: no such option: u
```

Removing the `-u` option seems to work just fine.
```
Salims-MBP:~ root# su "$SUDO_USER" /opt/chef-workstation/bin/chef_workstation_app_launcher load
Salims-MBP:~ root# su "$SUDO_USER" /opt/chef-workstation/bin/chef_workstation_app_launcher show
{
	"LimitLoadToSessionType" = "Aqua";
	"MachServices" = {
		"sh.chef.chef-workstation.MachPortRendezvousServer.22512" = mach-port-object;
	};
	"Label" = "io.chef.chef-workstation.app";
	"TimeOut" = 30;
	"OnDemand" = true;
	"LastExitStatus" = 0;
	"PID" = 22512;
	"Program" = "/Applications/Chef Workstation App.app/Contents/MacOS/Chef Workstation App";
	"ProgramArguments" = (
		"/Applications/Chef Workstation App.app/Contents/MacOS/Chef Workstation App";
	);
	"PerJobMachServices" = {
		"com.apple.tsm.portname" = mach-port-object;
		"com.apple.coredrag" = mach-port-object;
		"com.apple.axserver" = mach-port-object;
	};
};
```
Signed-off-by: Salim Afiune <afiune@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
https://github.com/chef/chef-workstation/pull/938

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
