### PR TITLE
Do not display errors on bg update checks

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -117,7 +117,7 @@ export class Main {
   }
 
   public triggerUpdateCheck(settings: TriggerUpdateSettings = {
-    UserRequest: true,
+    UserRequest: false,
     DisplayUpdateNotAvailableDialog: false
   }) {
     this.requestFromUser = settings.UserRequest;
@@ -212,10 +212,11 @@ export class Main {
     });
 
     this.omnitruckUpdateChecker.on('error', (error) => {
+      console.log("Failed to check for updates:  " + (error == null ? "no error given" :  error.toString()))
       if (this.requestFromUser) {
         // TODO probably don't show the error except to say try again later, UNLESS
         // we can identify a user-correctable problem (proxy,. etc)
-        dialog.showErrorBox('Error', error == null ? "unknown" : error.toString());
+        dialog.showErrorBox('Update Check Failed', error == null ? "Update service unavailable or unreachable" : error.toString());
       }
     });
 

--- a/src/preferences/preferences.ts
+++ b/src/preferences/preferences.ts
@@ -41,16 +41,16 @@ function toggleSetting(checkbox: HTMLInputElement) {
     }
     case 'software_updates': {
       AppConfig.setUpdatesEnable(checkbox.checked);
-
-      // when software updates are turned off, we shouldn't request a user update check
-      // this will prevent us from displaying an update after it was just disabled
-      ipcRenderer.send('do-update-check', {
-        UserRequest: checkbox.checked,
-        DisplayUpdateNotAvailableDialog: false
-      });
-
       // setup or clear the update interval
       if (checkbox.checked) {
+        ipcRenderer.send('do-update-check', {
+          // user did not say 'check for updates right now'
+          // only that auto-checks should get turned on. Marking
+          // user request as false ensurs we don't show popups or errors
+          // in a weird place/time (pref dialog)
+          UserRequest: false,
+          DisplayUpdateNotAvailableDialog: false
+        });
         ipcRenderer.send('setup-update-interval');
       } else {
         ipcRenderer.send('clear-update-interval');


### PR DESCRIPTION
This changes the default behavior of `triggerUpdateCheck` to
assume that the update check was not made by the user. This
takes care of various cases in which an automatic update
check is made in the background (or on startup), and failures
are shown as interrupting dialog boxes/popups.

Also added logging when an error event is received in update check,
made the error title more meaningful, and provided better text
for the "I do not know what the problem is" scenario.

This also updates the behavior of `preferences` to only
trigger a new update check if updates are enabled,
and to flag them as not user requested so that we don't
show a notification popup or an error when someone checks a
preferences checkbox.  We will still update the tray icon if an update is available.
Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>

Fixes #180 
Fixes #20 
Fixes #179 
