### PR TITLE
 (Reinstate)  Add Chef Habitat to product version output

### DIFF
--- a/src/about-dialog/package_details.html
+++ b/src/about-dialog/package_details.html
@@ -17,24 +17,28 @@
           version <script>document.write(workstation.getVersion())</script>
         </div>
         <div>
+          <h2>Chef Habitat</h2>
+          version <script>document.write(workstation.getInstalledComponentVersion('inspec'))</script>
+        </div>
+        <div>
+        <div>
           <h2>Chef Infra Client</h2>
-          version <script>document.write(workstation.getInstalledGemVersion('chef'))</script>
+          version <script>document.write(workstation.getInstalledComponentVersion('chef'))</script>
         </div>
         <div>
           <h2>Chef InSpec</h2>
-          version <script>document.write(workstation.getInstalledGemVersion('inspec'))</script>
+          version <script>document.write(workstation.getInstalledComponentVersion('inspec'))</script>
         </div>
-        <div>
           <h2>Test Kitchen</h2>
-          version <script>document.write(workstation.getInstalledGemVersion('test-kitchen'))</script>
+          version <script>document.write(workstation.getInstalledComponentVersion('test-kitchen'))</script>
         </div>
         <div>
           <h2>Chef CLI</h2>
-          version <script>document.write(workstation.getInstalledGemVersion('chef-cli'))</script>
+          version <script>document.write(workstation.getInstalledComponentVersion('chef-cli'))</script>
         </div>
         <div>
           <h2>Cookstyle</h2>
-          version <script>document.write(workstation.getInstalledGemVersion('cookstyle'))</script>
+          version <script>document.write(workstation.getInstalledComponentVersion('cookstyle'))</script>
         </div>
       </div>
       <div class="bottom-panel">

--- a/src/about-dialog/package_details.html
+++ b/src/about-dialog/package_details.html
@@ -17,11 +17,6 @@
           version <script>document.write(workstation.getVersion())</script>
         </div>
         <div>
-          <h2>Chef Habitat</h2>
-          version <script>document.write(workstation.getInstalledComponentVersion('inspec'))</script>
-        </div>
-        <div>
-        <div>
           <h2>Chef Infra Client</h2>
           version <script>document.write(workstation.getInstalledComponentVersion('chef'))</script>
         </div>
@@ -29,6 +24,11 @@
           <h2>Chef InSpec</h2>
           version <script>document.write(workstation.getInstalledComponentVersion('inspec'))</script>
         </div>
+        <div>
+          <h2>Chef Habitat</h2>
+          version <script>document.write(workstation.getInstalledComponentVersion('habitat'))</script>
+        </div>
+        <div>
           <h2>Test Kitchen</h2>
           version <script>document.write(workstation.getInstalledComponentVersion('test-kitchen'))</script>
         </div>


### PR DESCRIPTION
Also updates manifest-based version resolution to know how to
look for components in the version-manifest.json as a fallback to
gem-version-manifest.json

This reverts commit 5fcc46f80064ea5b5f2366eded5cb89fd9f78724. That was a
rollback commit against master, made after accidentally pushing this
change to master.


Partially handles chef/chef-workstation#1354
Requires chef/chef-workstation#1363 for version to display correctly.

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>
