### PR TITLE
Add links to the documentation + learn chef in the app

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -62,6 +62,15 @@ export class Main {
       },
       {type: 'separator'},
       {
+        label: 'Documentation',
+        click: () => { this.openDocs() }
+      },
+      {
+        label: 'Learn Chef',
+        click: () => { this.openLearn() }
+      },
+      {type: 'separator'},
+      {
         label: 'About ' + helpers.getDisplayName(),
         click: () => { aboutDialog.open() }
       },
@@ -128,6 +137,16 @@ export class Main {
   private downloadUpdate() {
     let result = shell.openExternal(this.pendingUpdate.url);
     console.log("Attempted to open URL: " + this.pendingUpdate.url + ". Result: " + result);
+  }
+
+  private openDocs() {
+    let result = shell.openExternal('https://docs.chef.io/');
+    console.log("Attempted to open URL: https://docs.chef.io/. Result: " + result);
+  }
+
+  private openLearn() {
+    let result = shell.openExternal('https://learn.chef.io/');
+    console.log("Attempted to open URL: https://learn.chef.io/. Result: " + result);
   }
 
   private startApp() {


### PR DESCRIPTION
This is really something we should have done day one. It just draws more users into the resources for our kit.

<img width="237" alt="image" src="https://user-images.githubusercontent.com/1015200/101437238-9507e480-38c4-11eb-8414-351f0174621a.png">

Signed-off-by: Tim Smith <tsmith@chef.io>