### PR TITLE
Make requests to omnitruck with an actual useragent

### DIFF
--- a/src/omnitruck-update-checker/omnitruck-update-checker.ts
+++ b/src/omnitruck-update-checker/omnitruck-update-checker.ts
@@ -38,7 +38,15 @@ export class OmnitruckUpdateChecker {
       "latest",
       this.platformInfo.kernel_machine);
 
-    request(url, { json: true }, (err, res, body) => {
+    let options = {
+      url: url,
+      headers: {
+        'User-Agent': 'chef-workstation-app / ' + currentVersion
+      },
+      json: true
+    };
+
+    request(options, (err, res, body) => {
       if (err)  {
         this.emitter.emit('error', err) ;
         this.emitter.emit('end-update-check');


### PR DESCRIPTION
We should identify the request to omnitruck as coming from Chef Workstation so we understand where our traffic is coming from:

With this change:

```
   "HTTP_USER_AGENT"=>"chef-workstation-app / 20.12.187",
```

Signed-off-by: Tim Smith <tsmith@chef.io>