### PR TITLE
On launch create the ~/.chef dir and credentials file if missing

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -173,15 +173,27 @@ export class Main {
     this.createChefDir();
   }
 
-  // make the ~/.chef directory if it doesn't exit
+  // make the ~/.chef directory if it doesn't exit and add a sample credentials file
   private createChefDir() {
     let os = require('os'),
-    fs = require('fs');
-    var dir = os.homedir() + '/.chef';
+    fs = require('fs'),
+    path = require('path');
+    let chefDir = os.homedir() + path.sep + '.chef';
 
-    if (!fs.existsSync(dir)) {
-        console.log("Creating the .chef dir at " + dir)
-        fs.mkdirSync(dir, 0o700);
+    if (!fs.existsSync(chefDir)) {
+        console.log("Creating the .chef dir at " + chefDir)
+        fs.mkdirSync(chefDir, 0o700);
+
+        let credentialsFile = chefDir + path.sep + "credentials";
+        let credentialContent = "# This is the Chef Infra credentials file used by the knife CLI and other tools\n" +
+                                "# This file supports defining multiple credentials profiles, to allow you to switch between users, orgs, and Chef Infra Servers.\n\n" +
+                                "# Example credential file configuration:\n" +
+                                "# [default]\n" +
+                                "# client_name = 'MY_USERNAME'\n" +
+                                "# client_key = '" + chefDir + path.sep + "MY_USERNAME.pem'\n" +
+                                "# chef_server_url = 'https://api.chef.io/organizations/MY_ORG'\n\n"
+        console.log("Creating the credentials file at " + credentialsFile);
+        fs.writeFileSync(credentialsFile, credentialContent);
     }
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -168,6 +168,21 @@ export class Main {
       this.triggerUpdateCheck();
       this.setupUpdateInterval();
     }
+
+    // Make sure we have a ~/.chef directory
+    this.createChefDir();
+  }
+
+  // make the ~/.chef directory if it doesn't exit
+  private createChefDir() {
+    let os = require('os'),
+    fs = require('fs');
+    var dir = os.homedir() + '/.chef';
+
+    if (!fs.existsSync(dir)) {
+        console.log("Creating the .chef dir at " + dir)
+        fs.mkdirSync(dir, 0o700);
+    }
   }
 
   private openPreferencesDialog() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -173,7 +173,7 @@ export class Main {
     this.createChefDir();
   }
 
-  // make the ~/.chef directory if it doesn't exit and add a sample credentials file
+  // make the ~/.chef directory if it doesn't exist and add a sample credentials file
   private createChefDir() {
     let os = require('os'),
     fs = require('fs'),

--- a/src/main.ts
+++ b/src/main.ts
@@ -178,19 +178,20 @@ export class Main {
     let os = require('os'),
     fs = require('fs'),
     path = require('path');
-    let chefDir = os.homedir() + path.sep + '.chef';
+    let chefDir = path.join(os.homedir(), '.chef')
 
     if (!fs.existsSync(chefDir)) {
         console.log("Creating the .chef dir at " + chefDir)
         fs.mkdirSync(chefDir, 0o700);
 
-        let credentialsFile = chefDir + path.sep + "credentials";
+        let credentialsFile =  path.join(chefDir, 'credentials');
+        let pemFile = path.join(chefDir, 'MY_USERNAME.pem');
         let credentialContent = "# This is the Chef Infra credentials file used by the knife CLI and other tools\n" +
                                 "# This file supports defining multiple credentials profiles, to allow you to switch between users, orgs, and Chef Infra Servers.\n\n" +
                                 "# Example credential file configuration:\n" +
                                 "# [default]\n" +
                                 "# client_name = 'MY_USERNAME'\n" +
-                                "# client_key = '" + chefDir + path.sep + "MY_USERNAME.pem'\n" +
+                                "# client_key = '" + pemFile + "'\n" +
                                 "# chef_server_url = 'https://api.chef.io/organizations/MY_ORG'\n\n"
         console.log("Creating the credentials file at " + credentialsFile);
         fs.writeFileSync(credentialsFile, credentialContent);


### PR DESCRIPTION
There's a lot of manual steps to getting started with Chef Infra. Let's remove two of them. On launch if there's no ~/.chef dir we know we're in a fresh install.

- Create the .chef dir
- Create a sample credentials file with a commented out profile

![image](https://user-images.githubusercontent.com/1015200/102043158-84ee7a00-3d88-11eb-83ac-c9cee2fe64d9.png)

Signed-off-by: Tim Smith <tsmith@chef.io>