### PR TITLE
Move electron-debug to be a dev dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1593,6 +1593,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/electron-debug/-/electron-debug-3.1.0.tgz",
       "integrity": "sha512-SWEqLj4MgfV3tGuO5eBLQ5/Nr6M+KPxsnE0bUJZvQebGJus6RAcdmvd7L+l0Ji31h2mmrN23l2tHFtCa2FvurA==",
+      "dev": true,
       "requires": {
         "electron-is-dev": "^1.1.0",
         "electron-localshortcut": "^3.1.0"
@@ -1601,7 +1602,8 @@
         "electron-is-dev": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/electron-is-dev/-/electron-is-dev-1.2.0.tgz",
-          "integrity": "sha512-R1oD5gMBPS7PVU8gJwH6CtT0e6VSoD0+SzSnYpNm+dBkcijgA+K7VAMHDfnRq/lkKPZArpzplTW6jfiMYosdzw=="
+          "integrity": "sha512-R1oD5gMBPS7PVU8gJwH6CtT0e6VSoD0+SzSnYpNm+dBkcijgA+K7VAMHDfnRq/lkKPZArpzplTW6jfiMYosdzw==",
+          "dev": true
         }
       }
     },
@@ -1700,7 +1702,8 @@
     "electron-is-accelerator": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/electron-is-accelerator/-/electron-is-accelerator-0.1.2.tgz",
-      "integrity": "sha1-UJ5RDCala1Xhf4Y6SwThEYRqsns="
+      "integrity": "sha1-UJ5RDCala1Xhf4Y6SwThEYRqsns=",
+      "dev": true
     },
     "electron-is-dev": {
       "version": "0.3.0",
@@ -1711,6 +1714,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/electron-localshortcut/-/electron-localshortcut-3.2.1.tgz",
       "integrity": "sha512-DWvhKv36GsdXKnaFFhEiK8kZZA+24/yFLgtTwJJHc7AFgDjNRIBJZ/jq62Y/dWv9E4ypYwrVWN2bVrCYw1uv7Q==",
+      "dev": true,
       "requires": {
         "debug": "^4.0.1",
         "electron-is-accelerator": "^0.1.0",
@@ -1719,17 +1723,19 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
         },
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
         }
       }
     },
@@ -2708,12 +2714,14 @@
     "keyboardevent-from-electron-accelerator": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/keyboardevent-from-electron-accelerator/-/keyboardevent-from-electron-accelerator-2.0.0.tgz",
-      "integrity": "sha512-iQcmNA0M4ETMNi0kG/q0h/43wZk7rMeKYrXP7sqKIJbHkTU8Koowgzv+ieR/vWJbOwxx5nDC3UnudZ0aLSu4VA=="
+      "integrity": "sha512-iQcmNA0M4ETMNi0kG/q0h/43wZk7rMeKYrXP7sqKIJbHkTU8Koowgzv+ieR/vWJbOwxx5nDC3UnudZ0aLSu4VA==",
+      "dev": true
     },
     "keyboardevents-areequal": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/keyboardevents-areequal/-/keyboardevents-areequal-0.2.2.tgz",
-      "integrity": "sha512-Nv+Kr33T0mEjxR500q+I6IWisOQ0lK1GGOncV0kWE6n4KFmpcu7RUX5/2B0EUtX51Cb0HjZ9VJsSY3u4cBa0kw=="
+      "integrity": "sha512-Nv+Kr33T0mEjxR500q+I6IWisOQ0lK1GGOncV0kWE6n4KFmpcu7RUX5/2B0EUtX51Cb0HjZ9VJsSY3u4cBa0kw==",
+      "dev": true
     },
     "keyv": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -38,11 +38,11 @@
     "rimraf": "^3.0.2",
     "spectron": "^10.0.1",
     "typescript": "^4.1.2",
-    "xvfb-maybe": "^0.2.1"
+    "xvfb-maybe": "^0.2.1",
+    "electron-debug": "^3.1.0"
   },
   "dependencies": {
     "@iarna/toml": "^2.2.5",
-    "electron-debug": "^3.1.0",
     "electron-is": "^3.0.0",
     "request": "^2.88.2"
   }


### PR DESCRIPTION
I don't see this being used anywhere in the shipped package

Signed-off-by: Tim Smith <tsmith@chef.io>