### PR TITLE
Pin to Electron 11.4.3 and remove the fs-extra pin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2005,9 +2005,9 @@
       }
     },
     "electron": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-11.3.0.tgz",
-      "integrity": "sha512-MhdS0gok3wZBTscLBbYrOhLaQybCSAfkupazbK1dMP5c+84eVMxJE/QGohiWQkzs0tVFIJsAHyN19YKPbelNrQ==",
+      "version": "11.4.3",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-11.4.3.tgz",
+      "integrity": "sha512-RhCWJqiYK5oIRGOheilhg/nngCgk0fPgaf00KvbxorlvFZAz8OeMT5ShCpVsMSoyYhk4XEnn4orRly5ltaFYJg==",
       "dev": true,
       "requires": {
         "@electron/get": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -27,11 +27,10 @@
     "test": "xvfb-maybe mocha test --full-stack"
   },
   "devDependencies": {
-    "@types/fs-extra": "9.0.11",
     "chai": "^4.3.4",
     "chai-as-promised": "^7.1.1",
     "copyfiles": "^2.4.1",
-    "electron": "^11.3.0",
+    "electron": "=11.4.3",
     "electron-builder": "22.10.5",
     "jsdom": "^16.5.3",
     "mocha": "^8.3.2",


### PR DESCRIPTION
The pin isn't needed anymore

Signed-off-by: Tim Smith <tsmith@chef.io>