### PR TITLE
Fix loading all helpers by turning off context isolation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3238,9 +3238,9 @@
           "dev": true
         },
         "ws": {
-          "version": "7.4.5",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.5.tgz",
-          "integrity": "sha512-xzyu3hFvomRfXKH8vOFMU3OguG6oOvhXMo3xsGy3xWExqaM2dxBbVxuD99O7m3ZUFMvvscsZDqxfgMaRr/Nr1g==",
+          "version": "7.4.6",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
+          "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
           "dev": true
         }
       }

--- a/src/about-dialog/about.js
+++ b/src/about-dialog/about.js
@@ -47,7 +47,8 @@ function openPackageDetails() {
       maximizable: false,
       show: false,
       webPreferences: {
-        nodeIntegration: true
+        nodeIntegration: true,
+        contextIsolation: false
       }
     });
     packageDetails.removeMenu();

--- a/src/about-dialog/about_dialog.js
+++ b/src/about-dialog/about_dialog.js
@@ -17,7 +17,8 @@ function open() {
       minimizable: false,
       maximizable: false,
       webPreferences: {
-        nodeIntegration: true
+        nodeIntegration: true,
+        contextIsolation: false
       }
     });
     aboutDialog.removeMenu();

--- a/src/main.ts
+++ b/src/main.ts
@@ -158,7 +158,8 @@ export class Main {
         // Electron does not recommend enabling this since it exposes sites to XSS attacks. Since we are
         // only distributing an app that is already running on someone's system we can get away with it but
         // we should switch to the 'preload' pattern documented in that tutorial.
-        nodeIntegration: true
+        nodeIntegration: true,
+        contextIsolation: false
       }
     });
     this.backgroundWindow.loadURL(modalPath)

--- a/src/no-update/no_update_dialog.js
+++ b/src/no-update/no_update_dialog.js
@@ -16,7 +16,8 @@ function open() {
       minimizable: false,
       maximizable: false,
       webPreferences: {
-        nodeIntegration: true
+        nodeIntegration: true,
+        contextIsolation: false
       }
     });
     noUpdateDialog.removeMenu();

--- a/src/preferences/preferences_dialog.ts
+++ b/src/preferences/preferences_dialog.ts
@@ -32,7 +32,8 @@ export class PreferencesDialog {
       minimizable: true,
       maximizable: false,
       webPreferences: {
-        nodeIntegration: true
+        nodeIntegration: true,
+        contextIsolation: false
       }
     });
     this.contentView = new BrowserView({ webPreferences: { nodeIntegration: true }});

--- a/src/update-available/update_available_dialog.js
+++ b/src/update-available/update_available_dialog.js
@@ -18,6 +18,7 @@ function open(updateInfo) {
       alwaysOnTop: true,
       webPreferences: {
         nodeIntegration: true,
+        contextIsolation: false,
         // We need to supply the available version to the browser window so it can
         // communicate this information to the user via the UI. Randomly passings
         // args to a window does not seem great but otherwise we need the window


### PR DESCRIPTION
Electron 12 made this the default which breaks requiring files and makes
all the helpers stop working. It basically breaks the whole app.

Signed-off-by: Tim Smith <tsmith@chef.io>