### PR TITLE
Fill out the `release` pipeline

### DIFF
--- a/.expeditor/buildkite/artifact_upload.sh
+++ b/.expeditor/buildkite/artifact_upload.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+ARTIFACTORY_TOKEN=$(vault kv get -field token account/static/artifactory/buildkite)
+VERSION="${VERSION:-$(cat VERSION)}"
+CHANNEL="${CHANNEL:-unstable}"
+
+# Download all the zip files from the builds
+rm -rf dist
+buildkite-agent artifact download "dist/*.zip" .
+buildkite-agent artifact download "dist\*.zip" .
+
+# # Upload them to Artifactory
+jfrog rt upload \
+    --apikey "$ARTIFACTORY_TOKEN" \
+    --url=https://artifactory.chef.co/artifactory \
+    --target-props="project=chef-workstation-app;version=${VERSION}" \
+    "dist/*.zip" \
+    "files-${CHANNEL}-local/chef-workstation-app/${VERSION}/"
+
+# Let folks know where to download the builds
+set +e # read exits 1 (even though it does what we weant)
+read -r -d '' final_annotation <<EOF
+The .zip files for the Chef Workstation App builds have been published to Artifactory and are available to download via packages.chef.io.
+
+- :macos: https://packages.chef.io/files/${CHANNEL}/chef-workstation-app/${VERSION}/chef-workstation-app-${VERSION}-darwin.zip
+- :linux: https://packages.chef.io/files/${CHANNEL}/chef-workstation-app/${VERSION}/chef-workstation-app-${VERSION}-linux.zip
+- :windows: https://packages.chef.io/files/${CHANNEL}/chef-workstation-app/${VERSION}/chef-workstation-app-${VERSION}-win32.zip
+EOF
+set -e
+
+buildkite-agent annotate "$final_annotation" --style info --context 'where-to-download'

--- a/.expeditor/buildkite/build_darwin.sh
+++ b/.expeditor/buildkite/build_darwin.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+# This job typically starts really quickly, so add a little note so folks don't get concerned
+buildkite-agent annotate 'The :windows: and :linux: jobs require booting a brand new instance. Those builds may take up to ten minutes to start.' --style info
+buildkite-agent annotate 'The .zip file for each build can be downloaded from the "Artifacts" tab in each build step. These links will not work for customers. Final links will be posted when `publish` step completes.' --style info --context 'where-to-download'
+
+# Install NodeJS
+brew install node@14
+brew link node@14
+
+# Perform the build
+npm install --unsafe-perm=true --allow-root
+npm run-script build-mac

--- a/.expeditor/buildkite/build_linux.sh
+++ b/.expeditor/buildkite/build_linux.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+# Install NodeJS
+curl -fsSL https://rpm.nodesource.com/setup_14.x | sudo bash -
+sudo yum install -y nodejs
+
+# Perform the build
+npm install --unsafe-perm=true --allow-root
+npm run-script build-linux

--- a/.expeditor/buildkite/build_win32.ps1
+++ b/.expeditor/buildkite/build_win32.ps1
@@ -1,0 +1,75 @@
+# Stop script execution when a non-terminating error occurs
+$ErrorActionPreference = "Stop"
+
+# A good chunk of this script was pulled from https://gist.github.com/noelmace/997a2e3d3ced0e1e6086066990036b16
+
+# Install NodeJSs
+$version = "14.17.4"
+$url = "https://nodejs.org/dist/v$version/node-v$version-x64.msi"
+$install_node = $TRUE
+
+### require administator rights
+
+if (-NOT ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator")) {
+  write-Warning "This setup needs admin permissions. Please run this file as admin."
+  break
+}
+
+### nodejs version check
+
+if (Get-Command node -errorAction SilentlyContinue) {
+  $current_version = (node -v)
+}
+
+if ($current_version) {
+  $install_node = $FALSE
+}
+
+if ($install_node) {
+
+  ### download nodejs msi file
+  # warning : if a node.msi file is already present in the current folder, this script will simply use it
+
+  write-host "`n----------------------------"
+  write-host "  nodejs msi file retrieving  "
+  write-host "----------------------------`n"
+
+  $filename = "node.msi"
+  $node_msi = "$env:TEMP\$filename"
+
+  $download_node = $TRUE
+
+  if (Test-Path $node_msi) {
+    $download_node = $FALSE
+  }
+
+  if ($download_node) {
+      write-host "[NODE] downloading nodejs install"
+      write-host "url : $url"
+      $start_time = Get-Date
+      $wc = New-Object System.Net.WebClient
+      $wc.DownloadFile($url, $node_msi)
+      write-Output "$filename downloaded"
+      write-Output "Time taken: $((Get-Date).Subtract($start_time).Seconds) second(s)"
+  } else {
+      write-host "using the existing node.msi file"
+  }
+
+  ### nodejs install
+
+  write-host "`n----------------------------"
+  write-host " nodejs installation  "
+  write-host "----------------------------`n"
+
+  write-host "[NODE] running $node_msi"
+  Start-Process $node_msi -Wait
+
+  $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
+
+} else {
+  write-host "Proceeding with the previously installed nodejs version ..."
+}
+
+# Perform the build
+npm install --unsafe-perm=true --allow-root
+npm run-script build-win

--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -6,7 +6,7 @@ slack:
   notify_channel: chef-ws-notify
 
 pipelines:
-  - build
+  - release
 
 github:
   # The tag format to use (e.g. v1.0.0)
@@ -31,5 +31,5 @@ subscriptions:
           ignore_labels:
             - "Expeditor: Skip Changelog"
             - "Expeditor: Skip All"
-      # - trigger_pipeline:build:
-      #     only_if: built_in:bump_version
+      - trigger_pipeline:release:
+          only_if: built_in:bump_version

--- a/.expeditor/release.pipeline.yml
+++ b/.expeditor/release.pipeline.yml
@@ -1,0 +1,38 @@
+steps:
+
+  - label: ":macos: build"
+    command: .expeditor/buildkite/build_darwin.sh
+    artifact_paths:
+      - dist/*.zip
+    expeditor:
+      executor:
+        macos:
+
+  - label: ":windows: build"
+    command: .expeditor/buildkite/build_win32.ps1
+    artifact_paths:
+      - dist/*.zip
+    expeditor:
+      executor:
+        windows:
+          single-use: true
+          privileged: true
+
+  - label: ":linux: build"
+    command: .expeditor/buildkite/build_linux.sh
+    artifact_paths:
+      - dist/*.zip
+    expeditor:
+      executor:
+        linux:
+          single-use: true
+          privileged: true
+
+  - wait
+
+  - label: ":artifactory: publish"
+    command: .expeditor/buildkite/artifact_upload.sh
+    expeditor:
+      secrets: true
+      executor:
+        docker:

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,4 +1,5 @@
 appId: "sh.chef.chef-workstation"
+artifactName: "${name}-${version}-${platform}.${ext}"
 
 extraMetadata:
   main: "./src/app.js"
@@ -26,8 +27,8 @@ mac:
     LSUIElement: 1
 
 win:
-  target: ["dir"]
+  target: ["dir", "zip"]
   icon: "assets/images/logo.ico"
 
 linux:
-  target: ["dir"]
+  target: ["dir", "zip"]


### PR DESCRIPTION
This pipeline will build zip's for all three platforms and upload them to Aritfactory. Once they are there, they can be pulled into Chef Workstation via the Omnibus build.

We current only have one channel (unstable) since this project is distributed via the Chef Workstation package.

Signed-off-by: Tom Duffield <github@tomduffield.com>