### PR TITLE
Upload zip from inside macOS VM

### DIFF
--- a/.expeditor/buildkite/build_darwin.sh
+++ b/.expeditor/buildkite/build_darwin.sh
@@ -13,3 +13,7 @@ brew link node@14
 # Perform the build
 npm install --unsafe-perm=true --allow-root
 npm run-script build-mac
+
+# Upload artifacts
+# This needs to happen inside the Anka VM (not on the host)
+buildkite-agent artifact upload dist/*.zip

--- a/.expeditor/release.pipeline.yml
+++ b/.expeditor/release.pipeline.yml
@@ -2,8 +2,6 @@ steps:
 
   - label: ":macos: build"
     command: .expeditor/buildkite/build_darwin.sh
-    artifact_paths:
-      - dist/*.zip
     expeditor:
       executor:
         macos:


### PR DESCRIPTION

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

FUSE was recently deprecated (for performance reasons) which means that files are no longer synced back to the host. This means we need to upload the zip file from inside the VM.

Signed-off-by: Tom Duffield <github@tomduffield.com>


## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

chef/release-engineering#1625

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
