### PR TITLE
Minor fix while copying plist to LaunchAgents directory

### DIFF
--- a/assets/scripts/chef_workstation_app_launcher
+++ b/assets/scripts/chef_workstation_app_launcher
@@ -103,7 +103,10 @@ startup()
       rm -f "$HOME/Library/LaunchAgents/${PLISTFILE}"
       ;;
     "enable")
-      cp "/Applications/Chef Workstation App.app/Contents/Resources/assets/${PLISTFILE}" "$HOME/Library/LaunchAgents"
+      if [ ! -d "$HOME/Library/LaunchAgents" ]; then
+        mkdir "$HOME/Library/LaunchAgents"
+      fi
+      cp "/Applications/Chef Workstation App.app/Contents/Resources/assets/${PLISTFILE}" "$HOME/Library/LaunchAgents/."
       ;;
     *)
       error_exit "invalid startup state '$1'.\\nValid states are 'enable' or 'disable'.\\nTry '--help' for more information."


### PR DESCRIPTION
Signed-off-by: Vikram Karve <vikram.karve@progress.com>

## Description
If user LaunchAgents dir missing, we need to create it. The earlier code would place the workstation app `.plist` file at `~/Library/LaunchAgents` effectively using that name as a file rather than directory, if it weren't present.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
