### PR TITLE
Restore builder to 10.15 as codesigning works here

### DIFF
--- a/.expeditor/release.pipeline.yml
+++ b/.expeditor/release.pipeline.yml
@@ -2,8 +2,10 @@ steps:
 
   - label: ":macos: Intel build"
     command: .expeditor/buildkite/build_darwin.sh
-    agents:
-      queue: omnibus-mac_os_x-11-x86_64
+    expeditor:
+      executor:
+        macos:
+          vm-name: buildkite-omnibus-mac_os_x-10.15-x86_64
 
   - label: ":macos: M1 build"
     command: .expeditor/buildkite/build_arm64.sh


### PR DESCRIPTION
Signed-off-by: Vikram Karve <vikram.karve@progress.com>

## Description
Codesigning doesn't work on macOS 11 builders, we'll look into this later.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
