### PR TITLE
Set increased timeout for Intel macOS verify run

### DIFF
--- a/.expeditor/buildkite/build_darwin.sh
+++ b/.expeditor/buildkite/build_darwin.sh
@@ -6,19 +6,7 @@ set -eu -o pipefail
 buildkite-agent annotate 'The :windows: and :linux: jobs require booting a brand new instance. Those builds may take up to ten minutes to start.' --style info
 buildkite-agent annotate 'The .zip file for each build can be downloaded from the "Artifacts" tab in each build step. These links will not work for customers. Final links will be posted when `publish` step completes.' --style info --context 'where-to-download'
 
-# Install dependencies & NodeJS, installing dependencies individually# is a workaround to the BuildKite timeout issue.
-# We can discard explicit dependency installation once we successfully migrate build to a macOS 11 agent.
-brew install libuv
-brew install libnghttp2
-brew install icu4c
-brew install c-ares
-brew install brotli
-brew install xz
-brew install sqlite
-brew install ca-certificates
-brew install mpdecimal
-brew install gdbm
-brew install python@3.10
+# Install NodeJS
 brew install node@18
 brew link node@18
 

--- a/.expeditor/buildkite/build_darwin.sh
+++ b/.expeditor/buildkite/build_darwin.sh
@@ -13,12 +13,12 @@ brew install libnghttp2
 brew install icu4c
 brew install c-ares
 brew install brotli
-brew install python@3.10
 brew install xz
 brew install sqlite
 brew install ca-certificates
 brew install mpdecimal
 brew install gdbm
+brew install python@3.10
 brew install node@18
 brew link node@18
 

--- a/.expeditor/buildkite/build_darwin.sh
+++ b/.expeditor/buildkite/build_darwin.sh
@@ -6,7 +6,19 @@ set -eu -o pipefail
 buildkite-agent annotate 'The :windows: and :linux: jobs require booting a brand new instance. Those builds may take up to ten minutes to start.' --style info
 buildkite-agent annotate 'The .zip file for each build can be downloaded from the "Artifacts" tab in each build step. These links will not work for customers. Final links will be posted when `publish` step completes.' --style info --context 'where-to-download'
 
-# Install NodeJS
+# Install dependencies & NodeJS, installing dependencies individually# is a workaround to the BuildKite timeout issue.
+# We can discard explicit dependency installation once we successfully migrate build to a macOS 11 agent.
+brew install libuv
+brew install libnghttp2
+brew install icu4c
+brew install c-ares
+brew install brotli
+brew install python@3.10
+brew install xz
+brew install sqlite
+brew install ca-certificates
+brew install mpdecimal
+brew install gdbm
 brew install node@18
 brew link node@18
 

--- a/.expeditor/release.pipeline.yml
+++ b/.expeditor/release.pipeline.yml
@@ -2,7 +2,7 @@ steps:
 
   - label: ":macos: Intel build"
     command: .expeditor/buildkite/build_darwin.sh
-    timeout_in_minutes: 30
+    timeout_in_minutes: 60
     expeditor:
       executor:
         macos:

--- a/.expeditor/release.pipeline.yml
+++ b/.expeditor/release.pipeline.yml
@@ -2,10 +2,8 @@ steps:
 
   - label: ":macos: Intel build"
     command: .expeditor/buildkite/build_darwin.sh
-    expeditor:
-      executor:
-        macos:
-          vm-name: buildkite-omnibus-mac_os_x-10.15-x86_64
+    agents:
+      queue: omnibus-mac_os_x-11-x86_64
 
   - label: ":macos: M1 build"
     command: .expeditor/buildkite/build_arm64.sh

--- a/.expeditor/release.pipeline.yml
+++ b/.expeditor/release.pipeline.yml
@@ -2,6 +2,7 @@ steps:
 
   - label: ":macos: Intel build"
     command: .expeditor/buildkite/build_darwin.sh
+    timeout_in_minutes: 30
     expeditor:
       executor:
         macos:

--- a/.expeditor/release.pipeline.yml
+++ b/.expeditor/release.pipeline.yml
@@ -2,8 +2,10 @@ steps:
 
   - label: ":macos: Intel build"
     command: .expeditor/buildkite/build_darwin.sh
-    agents:
-      queue: omnibus-mac_os_x-11-x86_64
+    expeditor:
+      executor:
+        macos:
+          vm-name: buildkite-omnibus-mac_os_x-10.15-x86_64
 
   - label: ":macos: M1 build"
     command: .expeditor/buildkite/build_arm64.sh


### PR DESCRIPTION
## Description
The verify run times out after 10 minutes on Intel macOS 10.15 agent. We will soon replace this with macOS 11 agent where the verify run happens quickly. For time being, setting increased timeout so verify runs don't fail.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
