### PR TITLE
workstation-app fixes

### DIFF
--- a/.expeditor/release.pipeline.yml
+++ b/.expeditor/release.pipeline.yml
@@ -6,7 +6,7 @@ steps:
     expeditor:
       executor:
         macos:
-          vm-name: buildkite-omnibus-mac_os_x-10.15-x86_64
+          vm-name: buildkite-omnibus-mac_os_x-11-x86_64
 
   - label: ":macos: M1 build"
     command: .expeditor/buildkite/build_arm64.sh

--- a/.expeditor/release.pipeline.yml
+++ b/.expeditor/release.pipeline.yml
@@ -10,6 +10,7 @@ steps:
 
   - label: ":macos: M1 build"
     command: .expeditor/buildkite/build_arm64.sh
+    timeout_in_minutes: 120
     agents:
       queue: omnibus-mac_os_x-11-arm64
 

--- a/assets/scripts/chef_workstation_app_launcher
+++ b/assets/scripts/chef_workstation_app_launcher
@@ -133,8 +133,14 @@ launchctl_load()
 
 launchctl_remove()
 {
-  if launchctl list "$SERVICENAME" >/dev/null 2>&1; then
-    launchctl remove "$SERVICENAME"
+
+  loggedInUser=$( ls -l /dev/console | awk '{print $3}' )
+
+  # Get loggedInUser ID
+  userID=$( id -u "$loggedInUser" )
+
+  if launchctl print "gui/$userID/$SERVICENAME" >/dev/null 2>&1; then
+    launchctl bootout "gui/$userID" "$HOME/Library/LaunchAgents/${PLISTFILE}"
   fi
 
   if [ -f "$HOME/Library/LaunchAgents/${PLISTFILE}" ]; then


### PR DESCRIPTION

## Description

- Updated the `launchctl list` and `remove` command with the `launchctl print` and `bootout` commands as they are depreciated and no longer working after  OS X 10.9 [ref](https://babodee.wordpress.com/2016/04/09/launchctl-2-0-syntax/). This fixes the unloading and removing of the LaunchAgent service running for workstaation-app and will close the tray icon when we uninstall chef-workstation.

## Related Issue
https://chefio.atlassian.net/browse/CHEF-11580

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
