### PR TITLE
CHEF-25763 - Remove SLA text from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Chef Workstation Tray Application
 
-**Umbrella Project**: [Workstation](https://github.com/chef/chef-oss-practices/blob/main/projects/chef-workstation.md)
+
 
 This the the tray application for Chef Workstation. It's written in Electron and is where we implement the UI based features of Chef Workstation.
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,6 @@
 
 **Umbrella Project**: [Workstation](https://github.com/chef/chef-oss-practices/blob/main/projects/chef-workstation.md)
 
-* **[Project State](https://github.com/chef/chef-oss-practices/blob/main/repo-management/repo-states.md):** Active
-* **Issues [Response Time Maximum](https://github.com/chef/chef-oss-practices/blob/main/repo-management/repo-states.md):** 14 days
-* **Pull Request [Response Time Maximum](https://github.com/chef/chef-oss-practices/blob/main/repo-management/repo-states.md):** 14 days
-
 This the the tray application for Chef Workstation. It's written in Electron and is where we implement the UI based features of Chef Workstation.
 
 ## Development


### PR DESCRIPTION
This pull request removes the oft-misleading Chef SLA text from the README.md file.

This action is being taken as part of the [2025 Repo Standardization Initiative](https://github.com/chef-boneyard/oss-repo-standardization-2025). 

As Progress Chef makes a best effort to respond to issues and pull requests in a timely manner, and prioritizes bugfixes and security updates on a customer-driven basis (which may span repos, or have no repo footprint at all), we no longer support the concept of a Service Level Agreement (SLA) on a repository-centric basis. For further details, see [Repo SLA Removal FAQ](https://github.com/chef-boneyard/oss-repo-standardization-2025/blob/main/messaging/sla-removal.md).